### PR TITLE
Tests basic functionality of the Explorer component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,11 @@ module.exports = {
     "react/jsx-no-bind": 0
   },
   globals: {
-    "fetch": true
+    "fetch": true,
+    "window": true,
+    "describe": true,
+    "beforeEach": true,
+    "afterEach": true,
+    "it": true,
   }
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@flowjs/flow.js": "^2.11.2",
     "actioncable": "5.0.2",
     "flux": "^3.1.2",
+    "moment": "^2.18.1",
     "node-sass": "^4.5.2",
     "object-assign": "^4.1.1",
     "prop-types": "^15.5.8",

--- a/src/scripts/components/dropstrip/dropstrip-store.jsx
+++ b/src/scripts/components/dropstrip/dropstrip-store.jsx
@@ -66,7 +66,7 @@ const DropstripStore = assign({}, EventEmitter.prototype, {
 
   success(filename) {
     dropzoneQueue[filename].completed = true;
-    resoundAPI.get(filename)
+    resoundAPI.get()
       .then(audioList => ExplorerActions.receiveAudioList(audioList));
   },
 

--- a/src/scripts/components/explorer/AudioItem.jsx
+++ b/src/scripts/components/explorer/AudioItem.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 const AudioItem = ({ audioItem }) => {
   const date = new Date(audioItem.created_at).toLocaleDateString();
   return (
-    <tr>
-      <td className="explorer__table-body__title">{audioItem.title}</td>
+    <tr className="explorer__table__audio-item">
+      <td className="explorer__table__audio-item-title">{audioItem.title}</td>
       <td>{audioItem.filename}</td>
       <td>{date}</td>
       <td>{audioItem.duration}</td>

--- a/src/scripts/components/explorer/AudioItem.jsx
+++ b/src/scripts/components/explorer/AudioItem.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
+import moment from 'moment';
 
 const AudioItem = ({ audioItem }) => {
   const date = new Date(audioItem.created_at).toLocaleDateString();
+  const durationInMilliseconds = audioItem.duration * 1000;
+  const duration = moment.utc(durationInMilliseconds).format('HH:mm:ss');
   return (
     <tr className="explorer__table__audio-item">
       <td className="explorer__table__audio-item-title">{audioItem.title}</td>
       <td>{audioItem.filename}</td>
-      <td>{date}</td>
-      <td>{audioItem.duration}</td>
+      <td className="explorer__table__audio-item-date">{date}</td>
+      <td className="explorer__table__audio-item-duration">{duration}</td>
     </tr>
   );
 };

--- a/src/scripts/components/explorer/explorer-store.jsx
+++ b/src/scripts/components/explorer/explorer-store.jsx
@@ -18,7 +18,7 @@ const ExplorerStore = assign({}, EventEmitter.prototype, {
   },
 
   getAudioList: (action) => {
-    if (action) audioList = action.response;
+    if (action) audioList = action.response || [];
     audioList.sort((a, b) => {
       const aDate = new Date(a.updated_at);
       const bDate = new Date(b.updated_at);

--- a/src/scripts/components/explorer/explorer-store.jsx
+++ b/src/scripts/components/explorer/explorer-store.jsx
@@ -18,7 +18,7 @@ const ExplorerStore = assign({}, EventEmitter.prototype, {
   },
 
   getAudioList: (action) => {
-    if (action) audioList = action.response || [];
+    if (action && action.response) audioList = action.response;
     audioList.sort((a, b) => {
       const aDate = new Date(a.updated_at);
       const bDate = new Date(b.updated_at);

--- a/src/scripts/components/explorer/explorer-store.jsx
+++ b/src/scripts/components/explorer/explorer-store.jsx
@@ -19,6 +19,11 @@ const ExplorerStore = assign({}, EventEmitter.prototype, {
 
   getAudioList: (action) => {
     if (action) audioList = action.response;
+    audioList.sort((a, b) => {
+      const aDate = new Date(a.updated_at);
+      const bDate = new Date(b.updated_at);
+      return bDate - aDate;
+    });
     return audioList;
   },
 });

--- a/test/explorer.spec.js
+++ b/test/explorer.spec.js
@@ -1,0 +1,31 @@
+global.WebSocket = require('ws');
+window.URL.createObjectURL = () => {
+  'http://fakeurl.wav'
+};
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-dom/test-utils'
+import Explorer from '../src/scripts/components/explorer/Explorer';
+import AudioItem from '../src/scripts/components/explorer/AudioItem';
+
+require('isomorphic-fetch');
+
+const _ = require('underscore');
+const expect = require('chai').expect;
+
+describe('<Explorer />', function() {
+  beforeEach(() => {
+    this.component = TestUtils.renderIntoDocument(<Explorer />);
+    this.stripDOM = ReactDOM.findDOMNode(this.component);
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(this.stripDOM.parentNode);
+  });
+
+  it('renders an AudioItem when a file is successfully uploaded', () => {
+
+  });
+});
+

--- a/test/explorer.spec.js
+++ b/test/explorer.spec.js
@@ -13,19 +13,86 @@ require('isomorphic-fetch');
 
 const _ = require('underscore');
 const expect = require('chai').expect;
+const sinon = require('sinon');
+const Promise = require('es6-promise').Promise;
+const ExplorerActions = require('../src/scripts/components/explorer/explorer-actions');
+const ExplorerStore = require('../src/scripts/components/explorer/explorer-store');
+const DropstripActions = require('../src/scripts/components/dropstrip/dropstrip-actions');
 
 describe('<Explorer />', function() {
   beforeEach(() => {
+    global.audioList = [];
     this.component = TestUtils.renderIntoDocument(<Explorer />);
     this.stripDOM = ReactDOM.findDOMNode(this.component);
   });
 
   afterEach(() => {
     ReactDOM.unmountComponentAtNode(this.stripDOM.parentNode);
+    global.audioList = [];
   });
 
-  it('renders an AudioItem when a file is successfully uploaded', () => {
+  const _respondWithFiles = (filesToMock = 1) => {
+    const files = [];
+    _(filesToMock).times((n) => {
+      const createdDate = new Date();
+      const updatedDate = new Date();
+      createdDate.setDate(n);
+      updatedDate.setDate(createdDate.getDate() + n);
 
+      files.push({
+        id: n,
+        filename: `fakeFile_${n}.wav`,
+        created_at: createdDate,
+        updated_at: updatedDate,
+        duration: '13.31',
+        title: `fakeTitle_${n}`,
+      });
+    });
+    return files;
+  };
+
+  it('renders a list of files', () => {
+    ExplorerActions.receiveAudioList(_respondWithFiles(5));
+    const fileList = this.stripDOM.getElementsByClassName('explorer__table__audio-item');
+    expect(fileList).to.have.length(5);
+  });
+
+  it('renders list of properties for each file', () => {
+    ExplorerActions.receiveAudioList(_respondWithFiles());
+    const audioItem = this.stripDOM.getElementsByClassName('explorer__table__audio-item')[0];
+    const properties = Array.from(audioItem.children);
+    let eachColumnIsRendered = true;
+    properties.forEach((cell) => {
+      if (!cell.innerHTML) eachColumnIsRendered = false;
+    });
+
+    expect(properties).to.have.length(4)
+    expect(eachColumnIsRendered).to.equal(true);
+  });
+
+  it('sorts the files by updated_at', () => {
+    const unsortedAudioList = _respondWithFiles(5).reverse();
+    ExplorerActions.receiveAudioList(unsortedAudioList);
+    const newlySortedAudioList = ExplorerStore.getAudioList();
+    let isSorted = true;
+    for (let i = 0; i < newlySortedAudioList.length - 1; i++) {
+      const currentUpdatedDate = new Date(newlySortedAudioList[i].updated_at);
+      const nextUpdatedDate = new Date(newlySortedAudioList[i + 1].updated_at);
+      if (currentUpdatedDate < nextUpdatedDate) {
+        isSorted = false;
+      }
+    }
+
+    expect(isSorted).to.equal(true);
+  });
+
+  it('adds a single file after a successful upload', () => {
+    const newList = ExplorerStore.getAudioList();
+    expect(newList).to.have.length(0);
+    DropstripActions.uploadSuccess('fakeFile_0.wav');
+    const audioItem = this.stripDOM.getElementsByClassName('explorer__table__audio-item');
+    console.log(audioItem);
+    expect(audioItem).to.exist;
   });
 });
 


### PR DESCRIPTION
@nakedsushi 

Notes:

- I added the test globals to .eslintrc
- I installed moment.js as a dependency for formatting durations (and date/times in the future)
- In `dropstrip-store.jsx`, I altered the `success` function to invoke `resound-api.get` without any arguments so that it returns a list with the new item at the top. However, I realize that you may have wanted the item to be solely rendered in the explorer by design. If that's the case, or if there are any other concerns, I can definitely change it back!
- I also added BEM classNames to the `AudioItems` for selection convenience.

Please let me know what you think, and if you have any thoughts and or concerns!