### PR TITLE
Refactors code to use react-autobind

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "object-assign": "^4.1.1",
     "prop-types": "^15.5.8",
     "react": "15.5.4",
+    "react-autobind": "^1.0.6",
     "react-autosuggest": "^9.3.1",
     "react-copy-to-clipboard": "^5.0.0",
     "react-dom": "15.5.4",

--- a/src/scripts/components/Header.jsx
+++ b/src/scripts/components/Header.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import autoBind from "react-autobind";
 import Errors from "../components/errors/Errors";
 import UserStore from "../stores/user-store";
 import ContributorStore from "../components/contributor/contributor-store";
@@ -8,8 +9,7 @@ export default class Header extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
-    this.login = this.login.bind(this);
-    this.logout = this.logout.bind(this);
+    autoBind(this);
   }
 
   componentWillMount() {

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -6,7 +6,7 @@ import AudioActions from "./audio-actions";
 import EditFile from "./EditFile";
 import Metadata from "./Metadata";
 import CopyDownload from "./CopyDownload";
-import bindHandlers from "../../services/bind-handlers";
+import autoBind from "react-autobind";
 import { isValidLength } from "../../services/audio-tools";
 import ContributorStore from "../../components/contributor/contributor-store";
 
@@ -23,18 +23,7 @@ export default class Audio extends React.Component {
     };
     this.wavesurfer = Wavesurfer;
     this.audioId = props.match.params.id.split("-")[0];
-    bindHandlers(this, [
-      "onChange",
-      "onTitleChange",
-      "onContributorsChange",
-      "onTagsChange",
-      "save",
-      "populateContributorsSuggestions",
-      "handleCloseModal",
-      "handleDeleteAudio",
-      "handleTogglePlay",
-      "handlePosChange"
-    ]);
+    autoBind(this);
   }
 
   componentDidMount() {

--- a/src/scripts/components/audio/EditFile.jsx
+++ b/src/scripts/components/audio/EditFile.jsx
@@ -1,11 +1,11 @@
 import React from "react";
-import bindHandlers from "../../services/bind-handlers";
+import autoBind from "react-autobind";
 import AudioActions from "./audio-actions";
 
 export default class EditFile extends React.Component {
   constructor(props) {
     super(props);
-    bindHandlers(this, ["onChange", "edit", "cancel"]);
+    autoBind(this);
   }
 
   componentDidMount() {}

--- a/src/scripts/components/contributor/Contributor.jsx
+++ b/src/scripts/components/contributor/Contributor.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Autosuggest from "react-autosuggest";
+import autoBind from "react-autobind";
 
 const renderSuggestion = suggestion =>
   <div>
@@ -12,14 +13,7 @@ export default class Contributor extends React.Component {
     this.state = {
       suggestions: []
     };
-    this.onChange = this.onChange.bind(this);
-    this.onSuggestionsFetchRequested = this.onSuggestionsFetchRequested.bind(
-      this
-    );
-    this.onSuggestionsClearRequested = this.onSuggestionsClearRequested.bind(
-      this
-    );
-    this.onGetSuggestionValue = this.onGetSuggestionValue.bind(this);
+    autoBind(this);
     this.MAX_CHAR_LENGTH = 4;
   }
 

--- a/src/scripts/components/dropstrip/Dropstrip.jsx
+++ b/src/scripts/components/dropstrip/Dropstrip.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Dropzone from "react-dropzone";
 import ActionCable from "actioncable";
+import autoBind from "react-autobind";
 import DropstripActions from "./dropstrip-actions";
 import DropstripStore from "./dropstrip-store";
 import QueuedItem from "./QueuedItem";
@@ -18,8 +19,7 @@ export default class Dropstrip extends React.Component {
       queue: getStateFromStore(),
       contributors: getContributorsFromStore()
     };
-    this.onChange = this.onChange.bind(this);
-    this.onContributorsChange = this.onContributorsChange.bind(this);
+    autoBind(this);
   }
 
   componentDidMount() {

--- a/src/scripts/components/dropstrip/QueuedItem.jsx
+++ b/src/scripts/components/dropstrip/QueuedItem.jsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import Contributor from "../contributor/Contributor";
 import DropstripActions from "./dropstrip-actions";
 import DropstripStore from "./dropstrip-store";
-import bindHandlers from "../../services/bind-handlers";
+import autoBind from "react-autobind";
 import { generateUrl, isValidLength } from "../../services/audio-tools";
 
 const getStateFromStore = () => DropstripStore.getQueue();
@@ -11,6 +11,8 @@ const getStateFromStore = () => DropstripStore.getQueue();
 class QueuedItem extends React.Component {
   constructor(props) {
     super(props);
+    autoBind(this);
+
     this.state = {
       title: "",
       contributors: "",
@@ -21,17 +23,6 @@ class QueuedItem extends React.Component {
     };
 
     this.MAX_CHAR_LENGTH = 4;
-
-    bindHandlers(this, [
-      "onChange",
-      "onPause",
-      "onResume",
-      "onCancel",
-      "onCancelConfirmed",
-      "onUpload",
-      "onSuccessOrFailure",
-      "onChangeContributor"
-    ]);
   }
 
   componentDidMount() {

--- a/src/scripts/components/errors/Errors.jsx
+++ b/src/scripts/components/errors/Errors.jsx
@@ -1,12 +1,12 @@
 import React from "react";
+import autoBind from "react-autobind";
 import ErrorsStore from "./errors-store";
 
 export default class Errors extends React.Component {
   constructor(props) {
     super(props);
     this.state = { msg: undefined };
-    this._displayError = this._displayError.bind(this);
-    this.dismiss = this.dismiss.bind(this);
+    autoBind(this);
   }
 
   componentDidMount() {

--- a/src/scripts/components/explorer/Explorer.jsx
+++ b/src/scripts/components/explorer/Explorer.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Pagination from "react-js-pagination";
+import autoBind from "react-autobind";
 import resoundAPI from "../../services/resound-api";
 import ExplorerStore from "./explorer-store";
 import ExplorerActions from "./explorer-actions";
@@ -16,7 +17,7 @@ export default class Explorer extends React.Component {
       audioList: [],
       isAppending: false
     };
-    this.onChange = this.onChange.bind(this);
+    autoBind(this);
   }
 
   componentDidMount() {

--- a/src/scripts/components/search/Search.jsx
+++ b/src/scripts/components/search/Search.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import autoBind from "react-autobind";
 import SearchActions from "./search-actions";
 import SearchStore from "./search-store";
 import ExplorerActions from "../explorer/explorer-actions";
@@ -9,9 +10,7 @@ export default class Search extends React.Component {
   constructor(props) {
     super(props);
     this.state = { query: "" };
-    this.onSubmit = this.onSubmit.bind(this);
-    this.onChange = this.onChange.bind(this);
-    this._searchReturned = this._searchReturned.bind(this);
+    autoBind(this);
   }
 
   componentDidMount() {

--- a/src/scripts/components/working-on/Working-on.jsx
+++ b/src/scripts/components/working-on/Working-on.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import autoBind from "react-autobind";
 import { Link } from "react-router-dom";
 import WorkingOnStore from "./working-on-store";
 import { generateUrl } from "../../services/audio-tools";
@@ -9,7 +10,7 @@ export default class WorkingOn extends React.Component {
     this.state = {
       audios: []
     };
-    this.onChange = this.onChange.bind(this);
+    autoBind(this);
   }
 
   componentDidMount() {

--- a/src/scripts/services/auth.js
+++ b/src/scripts/services/auth.js
@@ -1,4 +1,5 @@
 import auth0 from "auth0-js";
+import autoBind from "react-autobind";
 import AUTH_CONFIG from "../../config/auth0-variables";
 import UserActions from "../actions/user-actions";
 import ErrorsActions from "../components/errors/errors-actions";
@@ -13,11 +14,7 @@ export default class Auth {
       responseType: "token id_token",
       scope: "openid profile"
     });
-
-    this.login = this.login.bind(this);
-    this.logout = this.logout.bind(this);
-    this.handleAuthentication = this.handleAuthentication.bind(this);
-    this.getAccessToken = this.getAccessToken.bind(this);
+    autoBind(this);
   }
 
   handleAuthentication() {

--- a/src/scripts/services/bind-handlers.js
+++ b/src/scripts/services/bind-handlers.js
@@ -1,5 +1,0 @@
-export default function(object, arr) {
-  arr.forEach(handler => {
-    object[handler] = object[handler].bind(object);
-  });
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4619,6 +4619,10 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-autobind@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/react-autobind/-/react-autobind-1.0.6.tgz#936bb58edf6b89b619c50f82f0e617159fdfd4f1"
+
 react-autosuggest@^9.3.1:
   version "9.3.1"
   resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.3.1.tgz#cf106d95e650de292a08e6506372d3eb4b6b2614"


### PR DESCRIPTION
The combination of React and ES6 does not come with autobinding (https://facebook.github.io/react/blog/2015/01/27/react-v0.13.0-beta-1.html#autobinding), so I wrote a utility that does it. Turns out that there's already a package that does it better, so this refactor is to use that package.