### PR TITLE
Fix new filename bug

### DIFF
--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -29,7 +29,6 @@ export default class Audio extends React.Component {
     this.MAX_CHAR_LENGTH = 4;
     this.state = initialState;
     this.baseState = this.state;
-    this.wavesurfer = Wavesurfer;
     this.audioId = props.match.params.id.split("-")[0];
     autoBind(this);
   }
@@ -114,7 +113,14 @@ export default class Audio extends React.Component {
 
   onCompletedUpload() {
     AudioStore.fetch(this.audioId);
-    this.setState({ completed: true, replacing: false });
+    this.setState({
+      completed: true,
+      replacing: false
+    });
+    if (this.waveNode) {
+      const mp3Url = this.state.audio.files["mp3_128"];
+      this.waveNode._loadAudio(mp3Url);
+    }
   }
 
   onUploadError() {
@@ -269,6 +275,7 @@ export default class Audio extends React.Component {
                           onPosChange={this.handlePosChange}
                           playing={this.state.playing}
                           options={waveSurferOptions}
+                          ref={ref => (this.waveNode = ref)}
                         />
                       </div>
                       <button

--- a/src/scripts/components/audio/SingleAudioDropzone.jsx
+++ b/src/scripts/components/audio/SingleAudioDropzone.jsx
@@ -62,7 +62,8 @@ export default class SingleAudioDropzone extends React.Component {
       title: this.props.title,
       contributors: this.props.contributors,
       tags: this.props.tags,
-      name: this.file.name
+      name: this.file.name,
+      originalFilename: this.props.filename
     });
     this.setState({
       progress: "uploading"

--- a/src/scripts/components/dropstrip/dropstrip-store.jsx
+++ b/src/scripts/components/dropstrip/dropstrip-store.jsx
@@ -70,6 +70,7 @@ const DropstripStore = assign({}, EventEmitter.prototype, {
     dropzoneQueue[args.file.name].title = args.title;
     dropzoneQueue[args.file.name].contributors = args.contributors;
     dropzoneQueue[args.file.name].tags = args.tags;
+    dropzoneQueue[args.file.name].originalFilename = args.originalFilename;
     this.flow.addFile(file);
     this.flow.upload();
   },
@@ -154,7 +155,8 @@ DropstripStore.flow = new Flow({
   query: flowFile => ({
     title: dropzoneQueue[flowFile.name].title,
     contributors: dropzoneQueue[flowFile.name].contributors,
-    tags: dropzoneQueue[flowFile.name].tags
+    tags: dropzoneQueue[flowFile.name].tags,
+    originalFilename: dropzoneQueue[flowFile.name].originalFilename
   })
 });
 


### PR DESCRIPTION
Client side solution to https://github.com/ProjectResound/planning/issues/105

Sends the originalFilename of the audio file being replaced so that the server knows that we want to replace that filename with the new filename after a successful upload.

Also fixes a bug where the waveform was not reloading after the audio file got replaced.