### PR TITLE
Shows loading message when audio is being loaded into the player

### DIFF
--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -159,6 +159,10 @@ export default class Audio extends React.Component {
     if (this.state.inEditMode) {
       return;
     }
+    // Load the mp3 the first time user presses 'play'
+    if (!this.state.playing && !this.state.waveState) {
+      this.setState({ waveState: "loading" });
+    }
     this.setState({
       playing: !this.state.playing
     });
@@ -275,15 +279,23 @@ export default class Audio extends React.Component {
                       <div
                         className={editing ? "audio__waveform--disabled" : ""}
                       >
-                        <Wavesurfer
-                          audioFile={audio.files["mp3_128"]}
-                          pos={this.state.pos}
-                          onPosChange={this.handlePosChange}
-                          onFinish={this.handleTogglePlay}
-                          playing={this.state.playing}
-                          options={waveSurferOptions}
-                          ref={ref => (this.waveNode = ref)}
-                        />
+                        {this.state.waveState === "loading" &&
+                          <div className="audio__loading-msg">
+                            loading audio...
+                          </div>}
+                        {this.state.waveState &&
+                          <Wavesurfer
+                            audioFile={audio.files["mp3_128"]}
+                            pos={this.state.pos}
+                            onPosChange={this.handlePosChange}
+                            onFinish={this.handleTogglePlay}
+                            onReady={() => {
+                              this.setState({ waveState: "ready" });
+                            }}
+                            playing={this.state.playing}
+                            options={waveSurferOptions}
+                            ref={ref => (this.waveNode = ref)}
+                          />}
                       </div>
                       <button
                         className={replaceButtonClass}

--- a/src/styles/components/_audio-page.sass
+++ b/src/styles/components/_audio-page.sass
@@ -158,9 +158,15 @@
   .waveform__container
     margin-left: 75px
     position: relative
+    height: 75px
 
   .audio__waveform--disabled
     opacity: 0.5
+
+  .audio__loading-msg
+    color: $secondary-color
+    text-align: center
+    padding-top: 25px
 
   .replace__button
     border: 1px solid $primary-color


### PR DESCRIPTION
When a user visits the audio page of a large audio file, the page would start downloading the file immediately in order to generate the waveform for the player.  This commit changes that behavior. Instead of immediately downloading, it waits for the user to click 'play' first, shows a loading message, and then starts downloading the audio. Once the audio is downloaded into the player, it starts to play.

All of the above only happens the first time the user hits 'play'.  Any subsequent playings will go off of already downloaded data.