### PR TITLE
Shows error when no mp3 file is found.

### DIFF
--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -202,7 +202,7 @@ export default class Audio extends React.Component {
       replaceButtonClass = "replace__button";
     }
     let fileItems;
-    if (audio) {
+    if (audio && audio.files) {
       fileItems = Object.keys(audio.files).map(type =>
         <div key={type} className="file-list__item">
           {audio.files[type]}
@@ -264,7 +264,19 @@ export default class Audio extends React.Component {
                     tags={this.state.formTags}
                     filename={audio.filename}
                   />}
+                {!audio.files &&
+                  <div className="player__error">
+                    Could not find an mp3 file to load the audio player with.
+                    {!this.state.replacing &&
+                      <button
+                        className={replaceButtonClass}
+                        onClick={this.onReplacing}
+                      >
+                        Replace audio
+                      </button>}
+                  </div>}
                 {!this.state.replacing &&
+                  audio.files &&
                   <div className="row playwave__container">
                     <AudioPlayPause
                       editing={editing}

--- a/src/scripts/components/audio/CopyDownload.jsx
+++ b/src/scripts/components/audio/CopyDownload.jsx
@@ -1,10 +1,14 @@
 import React from "react";
 import CopyToClipboard from "react-copy-to-clipboard";
+import ErrorActions from "../../components/errors/errors-actions";
 
 export default class CopyDownload extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
+    if (!this.props.audio.files) {
+      ErrorsActions.error("Could not find audio files.");
+    }
   }
 
   render() {

--- a/src/scripts/components/dropstrip/dropstrip-store.jsx
+++ b/src/scripts/components/dropstrip/dropstrip-store.jsx
@@ -106,6 +106,18 @@ const DropstripStore = assign({}, EventEmitter.prototype, {
   }
 });
 
+const buildFlowQuery = flowFile => {
+  const queryObj = {
+    title: dropzoneQueue[flowFile.name].title,
+    contributors: dropzoneQueue[flowFile.name].contributors,
+    tags: dropzoneQueue[flowFile.name].tags
+  };
+  if (dropzoneQueue[flowFile.name].originalFilename) {
+    queryObj.originalFilename = dropzoneQueue[flowFile.name].originalFilename;
+  }
+  return queryObj;
+};
+
 AppDispatcher.register(action => {
   let successFlag;
   switch (action.actionType) {
@@ -152,12 +164,7 @@ DropstripStore.flow = new Flow({
   testChunks: false,
   headers: resoundAPI.headers,
   simultaneousUploads: 6,
-  query: flowFile => ({
-    title: dropzoneQueue[flowFile.name].title,
-    contributors: dropzoneQueue[flowFile.name].contributors,
-    tags: dropzoneQueue[flowFile.name].tags,
-    originalFilename: dropzoneQueue[flowFile.name].originalFilename
-  })
+  query: buildFlowQuery
 });
 
 DropstripStore.flow.on("fileProgress", flowFile => {

--- a/src/styles/components/_audio-page.sass
+++ b/src/styles/components/_audio-page.sass
@@ -147,6 +147,11 @@
   .error__message
     color: $error-color
 
+  .player__error
+    color: $error-color
+    position: relative
+    height: 75px
+
   =waveform_button
     width: 75px
     cursor: pointer


### PR DESCRIPTION
* the transitional state when the upload is done, but the transcoding is still happening causes audio not to have files associated with it yet. This bugfix fixes the display of that.
* prevents adding 'undefined' as the originalFilename query string