### PR TITLE
Adds honeybadger error monitoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "auth0-js": "^8.7.0",
     "expose-loader": "^0.7.3",
     "flux": "^3.1.2",
+    "honeybadger-js": "^0.5.1",
     "moment": "^2.18.1",
     "node-sass": "^4.5.2",
     "object-assign": "^4.1.1",

--- a/src/scripts/app.jsx
+++ b/src/scripts/app.jsx
@@ -9,6 +9,12 @@ import resoundAPI from "./services/resound-api";
 import Audio from "./components/audio/Audio";
 import "../styles/main.sass";
 
+const Honeybadger = require("honeybadger-js");
+Honeybadger.configure({
+  apiKey: process.env.HONEYBADGER_CLIENT_KEY,
+  environment: process.env.NODE_ENV
+});
+
 const auth = resoundAPI.auth;
 
 class Root extends React.Component {

--- a/src/scripts/components/errors/errors-store.jsx
+++ b/src/scripts/components/errors/errors-store.jsx
@@ -19,9 +19,6 @@ const ErrorsStore = assign({}, EventEmitter.prototype, {
     if (action.err && action.err.message === "Failed to fetch") {
       ErrorsStore.emitChange("There was an error contacting the server.");
     }
-    if (process.env.NODE_ENV === "development") {
-      console.dir(action);
-    }
   }
 });
 

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -34,6 +34,9 @@ module.exports = {
     new webpack.DefinePlugin({
       "process.env": {
         NODE_ENV: JSON.stringify("production"),
+        HONEYBADGER_CLIENT_KEY: JSON.stringify(
+          process.env.HONEYBADGER_CLIENT_KEY
+        ),
         AUTH0_DOMAIN: JSON.stringify("MAGICSTRING_AUTH0_DOMAIN"),
         AUTH0_CLIENT_ID: JSON.stringify("MAGICSTRING_AUTH0_CLIENT_ID"),
         AUTH0_CALLBACK_URL: JSON.stringify("MAGICSTRING_AUTH0_CALLBACK_URL"),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2862,6 +2862,10 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
+honeybadger-js@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/honeybadger-js/-/honeybadger-js-0.5.1.tgz#0fe597cac88ecb5b5099479ab49f6f0d7d7f1716"
+
 hosted-git-info@^2.1.4:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.1.tgz#4b0445e41c004a8bd1337773a4ff790ca40318c8"


### PR DESCRIPTION
* I stored our api key an env variable so that admins have the option of using their own key if they want.
* I got rid of some temporary logging that I was using since it's unnecessary now that we have real error reporting
* I set it so that it only logs to honeybadger in production, since we can already see errors in console log in dev.