### PR TITLE
Remove Auth0 SSO cookie on logout

### DIFF
--- a/src/scripts/services/auth.js
+++ b/src/scripts/services/auth.js
@@ -56,6 +56,9 @@ export default class Auth {
       localStorage.removeItem("id_token");
       localStorage.removeItem("expires_at");
     }
+
+    // Clear the SSO cookie in Auth0
+    fetch(`https://${AUTH_CONFIG.domain}/v2/logout`, { mode: "no-cors" });
     UserActions.loggedOut();
   }
 

--- a/src/scripts/services/auth.js
+++ b/src/scripts/services/auth.js
@@ -58,8 +58,12 @@ export default class Auth {
     }
 
     // Clear the SSO cookie in Auth0
-    fetch(`https://${AUTH_CONFIG.domain}/v2/logout`, { mode: "no-cors" });
-    UserActions.loggedOut();
+    fetch(`https://${AUTH_CONFIG.domain}/v2/logout`, {
+      credentials: "include",
+      mode: "no-cors"
+    })
+      .then(res => UserActions.loggedOut())
+      .catch(err => ErrorsActions.error(err));
   }
 
   get isAuthenticated() {

--- a/test/e2e/logging-out.js
+++ b/test/e2e/logging-out.js
@@ -1,0 +1,22 @@
+import { Selector, Role } from 'testcafe';
+
+
+const indexPage = "http://localhost:8000";
+
+const louise = Role(indexPage, async t => {
+  await t
+    .typeText('[name="email"]', process.env.TESTCAFE_EMAIL)
+    .typeText('[name="password"]', process.env.TESTCAFE_PW)
+    .click('[type="submit"]');
+});
+
+fixture("Logged In")
+  .page(indexPage);
+
+test("Logging out", async t => {
+  await t
+    .useRole(louise)
+    .navigateTo(indexPage)
+    .click(".header__button")
+    .expect(Selector(".auth0-lock-input").exists).ok()
+});


### PR DESCRIPTION
In this pull request, I cleared the SSO cookie in Auth0 by fetch calling the logout url. I also created a test where it logs in and then logs out. After logout, it checks if there are an email and password input to see if the user will need to put in their credentials after every logout. The test passes for Chrome, Firefox, and Safari. I have also seen Jonatas' implementation for the logout and all the test passes for that also.