### PR TITLE
Fix bug where alert does not show up when clicking on "See all your activity"

### DIFF
--- a/src/scripts/components/working-on/Working-on.jsx
+++ b/src/scripts/components/working-on/Working-on.jsx
@@ -48,7 +48,7 @@ export default class WorkingOn extends React.Component {
               What You&apos;ve Been Working On
             </div>
             <div className="working-on__more-link col s4">
-              <a href="activity">See all your activity</a>
+              <Link to="/activity">See all your activity</Link>
             </div>
           </div>
           <div className="working-on__audios">{audios}</div>


### PR DESCRIPTION
In this pull request, an alert should show up when a user clicks on "See all your activity" when an audio is in the dropzone. It seems like using the Link component notifies React Router that you are navigating away from the page which will trigger the Prompt component to show the alert.