### PR TITLE
Create/embed

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "moment": "^2.18.1",
     "node-sass": "^4.9.3",
     "object-assign": "^4.1.1",
+    "query-string": "^6.2.0",
     "react": "^16.3.1",
     "react-autobind": "^1.0.6",
     "react-autosuggest": "^9.3.1",

--- a/src/scripts/app.jsx
+++ b/src/scripts/app.jsx
@@ -28,7 +28,6 @@ class Root extends React.Component {
   render() {
     return (
       <div>
-        <Route path="/embed" component={Embed} />
         <Route
           render={history => (
             <Header
@@ -43,6 +42,7 @@ class Root extends React.Component {
             <Route exact path="/" component={StoreManageApp} />
             <Route path="/audio/:id" component={Audio} />
             <Route path="/activity" component={Activity} />
+            <Route path="/embed" component={Embed} />
           </div>
         )}
       </div>

--- a/src/scripts/app.jsx
+++ b/src/scripts/app.jsx
@@ -28,6 +28,7 @@ class Root extends React.Component {
   render() {
     return (
       <div>
+        <Route path="/embed" component={Embed} />
         <Route
           render={history => (
             <Header
@@ -42,7 +43,6 @@ class Root extends React.Component {
             <Route exact path="/" component={StoreManageApp} />
             <Route path="/audio/:id" component={Audio} />
             <Route path="/activity" component={Activity} />
-            <Route path="/embed" component={Embed} />
           </div>
         )}
       </div>

--- a/src/scripts/app.jsx
+++ b/src/scripts/app.jsx
@@ -7,6 +7,7 @@ import StoreManageApp from "./StoreManageApp";
 import resoundAPI from "./services/resound-api";
 import Audio from "./components/audio/Audio";
 import Activity from "./components/activity/Activity";
+import Embed from "./components/embed/Embed";
 import "../styles/main.sass";
 
 const Honeybadger = require("honeybadger-js");
@@ -41,6 +42,7 @@ class Root extends React.Component {
             <Route exact path="/" component={StoreManageApp} />
             <Route path="/audio/:id" component={Audio} />
             <Route path="/activity" component={Activity} />
+            <Route path="/embed" component={Embed} />
           </div>
         )}
       </div>

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -205,7 +205,7 @@ export default class Audio extends React.Component {
     const { contributors, files, title } = audio;
 
     const iframeSrcObj = {
-      audio: files["mp3_128"],
+      url: files["mp3_128"],
       contributors,
       title
     };

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -18,7 +18,7 @@ import DropstripStore from "../dropstrip/dropstrip-store";
 import queryString from "query-string";
 
 const initialState = {
-  encodedImageUrl: "",
+  imageUrl: "",
   inEditMode: false,
   validTitle: true,
   validContributors: true,
@@ -201,7 +201,7 @@ export default class Audio extends React.Component {
   }
 
   updateIframeSrc(audio) {
-    const { encodedImageUrl } = this.state;
+    const { imageUrl } = this.state;
     const { contributors, files, title } = audio;
 
     const iframeSrcObj = {
@@ -210,8 +210,8 @@ export default class Audio extends React.Component {
       title
     };
 
-    if (encodedImageUrl) {
-      iframeSrcObj.image = encodedImageUrl;
+    if (imageUrl) {
+      iframeSrcObj.image = imageUrl;
     }
 
     const iframeSrc = `/embed?${queryString.stringify(iframeSrcObj)}`;
@@ -221,9 +221,7 @@ export default class Audio extends React.Component {
 
   updateImage(e) {
     const imageUrl = e.target.value;
-    const encodedImageUrl = encodeURIComponent(imageUrl);
-
-    this.setState({ encodedImageUrl });
+    this.setState({ imageUrl });
   }
 
   render() {

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -367,7 +367,9 @@ export default class Audio extends React.Component {
         />
         <iframe
           id="embeddable-audio-player"
-          src={`/embed?image=${this.state.encodedImageUrl}`}
+          src={`/embed?title=${audio ? audio.title : ""}
+          &contributors=${audio ? audio.contributors : ""}
+          ${this.state.encodedImageUrl ? `&image=${this.state.encodedImageUrl}` : ""}`}
         />
       </div>
     );

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -332,7 +332,7 @@ export default class Audio extends React.Component {
                           )}
                           {this.state.waveState && (
                             <Wavesurfer
-                              audioFile={audio.files["mp3_128"]}
+                              audioFile={`http://localhost:3000${audio.files["mp3_128"]}`}
                               pos={this.state.pos}
                               onPosChange={this.handlePosChange}
                               onFinish={this.handleTogglePlay}

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -17,6 +17,7 @@ import SingleAudioDropzone from "./SingleAudioDropzone";
 import DropstripStore from "../dropstrip/dropstrip-store";
 
 const initialState = {
+  encodedImageUrl: "",
   inEditMode: false,
   validTitle: true,
   validContributors: true,
@@ -198,6 +199,13 @@ export default class Audio extends React.Component {
     });
   }
 
+  updateImage(e) {
+    const imageUrl = e.target.value;
+    var encodedImageUrl = encodeURIComponent(imageUrl);
+
+    this.setState({ encodedImageUrl });
+  }
+
   render() {
     const audio = this.state.audio;
     const editing = this.state.inEditMode;
@@ -351,7 +359,16 @@ export default class Audio extends React.Component {
             </div>
           </div>
         )}
-        <iframe id="embeddable-audio-player" src="/embed" />
+        <input
+          id="image-url"
+          onChange={this.updateImage}
+          placeholder="Insert Image URL here"
+          type="text"
+        />
+        <iframe
+          id="embeddable-audio-player"
+          src={`/embed?image=${this.state.encodedImageUrl}`}
+        />
       </div>
     );
   }

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -15,6 +15,7 @@ import { getDuration, isValidLength } from "../../services/audio-tools";
 import ContributorStore from "../../components/contributor/contributor-store";
 import SingleAudioDropzone from "./SingleAudioDropzone";
 import DropstripStore from "../dropstrip/dropstrip-store";
+import queryString from "query-string";
 
 const initialState = {
   encodedImageUrl: "",
@@ -199,6 +200,25 @@ export default class Audio extends React.Component {
     });
   }
 
+  updateIframeSrc(audio) {
+    const { encodedImageUrl } = this.state;
+    const { contributors, files, title } = audio;
+
+    const iframeSrcObj = {
+      audio: files["mp3_128"],
+      contributors,
+      title
+    };
+
+    if (encodedImageUrl) {
+      iframeSrcObj.image = encodedImageUrl;
+    }
+
+    const iframeSrc = `/embed?${queryString.stringify(iframeSrcObj)}`;
+
+    return iframeSrc;
+  }
+
   updateImage(e) {
     const imageUrl = e.target.value;
     var encodedImageUrl = encodeURIComponent(imageUrl);
@@ -365,12 +385,12 @@ export default class Audio extends React.Component {
           placeholder="Insert Image URL here"
           type="text"
         />
-        <iframe
-          id="embeddable-audio-player"
-          src={`/embed?title=${audio ? audio.title : ""}
-          &contributors=${audio ? audio.contributors : ""}
-          ${this.state.encodedImageUrl ? `&image=${this.state.encodedImageUrl}` : ""}`}
-        />
+        {audio && (
+          <iframe
+            id="embeddable-audio-player"
+            src={this.updateIframeSrc(audio)}
+          />
+        )}
       </div>
     );
   }

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -221,7 +221,7 @@ export default class Audio extends React.Component {
 
   updateImage(e) {
     const imageUrl = e.target.value;
-    var encodedImageUrl = encodeURIComponent(imageUrl);
+    const encodedImageUrl = encodeURIComponent(imageUrl);
 
     this.setState({ encodedImageUrl });
   }

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -351,6 +351,7 @@ export default class Audio extends React.Component {
             </div>
           </div>
         )}
+        <iframe id="embeddable-audio-player" src="/embed" />
       </div>
     );
   }

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -332,7 +332,9 @@ export default class Audio extends React.Component {
                           )}
                           {this.state.waveState && (
                             <Wavesurfer
-                              audioFile={`http://localhost:3000${audio.files["mp3_128"]}`}
+                              audioFile={`http://localhost:3000${
+                                audio.files["mp3_128"]
+                              }`}
                               pos={this.state.pos}
                               onPosChange={this.handlePosChange}
                               onFinish={this.handleTogglePlay}

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -1,0 +1,40 @@
+import React, { Component } from "react";
+import autoBind from "react-autobind";
+import Wavesurfer from "react-wavesurfer";
+
+class Embed extends Component {
+  constructor(props) {
+  	super(props);
+
+  	this.state = {
+  		playing: false,
+  	}
+
+    autoBind(this);
+  }
+
+  handleTogglePlay() {
+  	const { playing } = this.state;
+
+  	this.setState({ playing: !playing });
+  }
+
+  render() {
+	  return (
+      <div id="embed">
+        <Wavesurfer
+	  	    audioFile={'https://ia902606.us.archive.org/35/items/shortpoetry_047_librivox/song_cjrg_teasdale_64kb.mp3'}
+	  	    playing={this.state.playing}
+        />
+        <div
+          id="embed__play-pause"
+          onClick={this.handleTogglePlay}
+        >
+          Play | Pause
+        </div>
+      </div>
+	  );
+  }
+}
+
+export default Embed;

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -1,39 +1,47 @@
 import React, { Component } from "react";
 import autoBind from "react-autobind";
 import Wavesurfer from "react-wavesurfer";
+import queryString from "query-string";
 
 class Embed extends Component {
   constructor(props) {
-  	super(props);
+    super(props);
 
-  	this.state = {
-  		playing: false,
-  	}
+    this.state = {
+      imageUrl: null,
+      playing: false
+    };
 
     autoBind(this);
   }
 
-  handleTogglePlay() {
-  	const { playing } = this.state;
+  componentDidMount() {
+    const values = queryString.parse(this.props.location.search);
+    this.setState({ imageUrl: values.image });
+  }
 
-  	this.setState({ playing: !playing });
+  handleTogglePlay() {
+    const { playing } = this.state;
+    this.setState({ playing: !playing });
   }
 
   render() {
-	  return (
+    return (
       <div id="embed">
+        {this.state.imageUrl && (
+          <img id="embed__image" src={this.state.imageUrl} />
+        )}
         <Wavesurfer
-	  	    audioFile={'https://ia902606.us.archive.org/35/items/shortpoetry_047_librivox/song_cjrg_teasdale_64kb.mp3'}
-	  	    playing={this.state.playing}
+          audioFile={
+            "https://ia902606.us.archive.org/35/items/shortpoetry_047_librivox/song_cjrg_teasdale_64kb.mp3"
+          }
+          playing={this.state.playing}
         />
-        <div
-          id="embed__play-pause"
-          onClick={this.handleTogglePlay}
-        >
-          {this.state.playing ? 'Pause' : 'Play'}
+        <div id="embed__play-pause" onClick={this.handleTogglePlay}>
+          {this.state.playing ? "Pause" : "Play"}
         </div>
       </div>
-	  );
+    );
   }
 }
 

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -10,15 +10,15 @@ class Embed extends Component {
 
     this.state = {
       playing: false,
-      song: {}
+      audio: {}
     };
 
     autoBind(this);
   }
 
   componentDidMount() {
-    const song = queryString.parse(this.props.location.search);
-    this.setState({ song });
+    const audio = queryString.parse(this.props.location.search);
+    this.setState({ audio });
   }
 
   handlePosChange(e) {
@@ -35,15 +35,15 @@ class Embed extends Component {
   }
 
   render() {
-    const { song } = this.state;
+    const { audio } = this.state;
 
     return (
       <div id="embed">
-        <h3>{song.title}</h3>
-        <p>{song.contributors}</p>
-        {song.image && <img id="embed__image" src={song.image} />}
+        <h3>{audio.title}</h3>
+        <p>{audio.contributors}</p>
+        {audio.image && <img id="embed__image" src={audio.image} />}
         <Wavesurfer
-          audioFile={`http://localhost:3000/${song.audio}`}
+          audioFile={`http://localhost:3000/${audio.url}`}
           onPosChange={this.handlePosChange}
           playing={this.state.playing}
         />

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { getDuration } from "../../services/audio-tools";
 import autoBind from "react-autobind";
 import Wavesurfer from "react-wavesurfer";
 import queryString from "query-string";
@@ -20,6 +21,14 @@ class Embed extends Component {
     this.setState({ song });
   }
 
+  handlePosChange(e) {
+    const pos = e.originalArgs[0];
+
+    this.setState({
+      timestamp: getDuration({ duration: pos })
+    });
+  }
+
   handleTogglePlay() {
     const { playing } = this.state;
     this.setState({ playing: !playing });
@@ -35,8 +44,10 @@ class Embed extends Component {
         {song.image && <img id="embed__image" src={song.image} />}
         <Wavesurfer
           audioFile={`http://localhost:3000/${song.audio}`}
+          onPosChange={this.handlePosChange}
           playing={this.state.playing}
         />
+        <div id="embed__timestamp">{this.state.timestamp}</div>
         <div id="embed__play-pause" onClick={this.handleTogglePlay}>
           {this.state.playing ? "Pause" : "Play"}
         </div>

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -30,7 +30,7 @@ class Embed extends Component {
           id="embed__play-pause"
           onClick={this.handleTogglePlay}
         >
-          Play | Pause
+          {this.state.playing ? 'Pause' : 'Play'}
         </div>
       </div>
 	  );

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -34,7 +34,7 @@ class Embed extends Component {
         <p>{song.contributors}</p>
         {song.image && <img id="embed__image" src={song.image} />}
         <Wavesurfer
-          audioFile={song.audio}
+          audioFile={`http://localhost:3000/${song.audio}`}
           playing={this.state.playing}
         />
         <div id="embed__play-pause" onClick={this.handleTogglePlay}>

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -34,9 +34,7 @@ class Embed extends Component {
         <p>{song.contributors}</p>
         {song.image && <img id="embed__image" src={song.image} />}
         <Wavesurfer
-          audioFile={
-            "https://ia902606.us.archive.org/35/items/shortpoetry_047_librivox/song_cjrg_teasdale_64kb.mp3"
-          }
+          audioFile={song.audio}
           playing={this.state.playing}
         />
         <div id="embed__play-pause" onClick={this.handleTogglePlay}>

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -8,16 +8,16 @@ class Embed extends Component {
     super(props);
 
     this.state = {
-      imageUrl: null,
-      playing: false
+      playing: false,
+      song: {}
     };
 
     autoBind(this);
   }
 
   componentDidMount() {
-    const values = queryString.parse(this.props.location.search);
-    this.setState({ imageUrl: values.image });
+    const song = queryString.parse(this.props.location.search);
+    this.setState({ song });
   }
 
   handleTogglePlay() {
@@ -26,11 +26,13 @@ class Embed extends Component {
   }
 
   render() {
+    const { song } = this.state;
+
     return (
       <div id="embed">
-        {this.state.imageUrl && (
-          <img id="embed__image" src={this.state.imageUrl} />
-        )}
+        <h3>{song.title}</h3>
+        <p>{song.contributors}</p>
+        {song.image && <img id="embed__image" src={song.image} />}
         <Wavesurfer
           audioFile={
             "https://ia902606.us.archive.org/35/items/shortpoetry_047_librivox/song_cjrg_teasdale_64kb.mp3"

--- a/src/styles/components/_audio-page.sass
+++ b/src/styles/components/_audio-page.sass
@@ -267,6 +267,9 @@
     text-align: right
     font-size: 0.7rem
 
+#embeddable-audio-player
+  width: 100%
+
 =delete_button
   width: 55px
   margin: 20px 5px

--- a/src/styles/components/_embed.sass
+++ b/src/styles/components/_embed.sass
@@ -1,0 +1,2 @@
+#embed__play-pause:hover
+  cursor: pointer

--- a/src/styles/components/_embed.sass
+++ b/src/styles/components/_embed.sass
@@ -1,2 +1,6 @@
 #embed__play-pause:hover
   cursor: pointer
+
+#embed__image
+	height: 100px
+	width: 100px

--- a/src/styles/main.sass
+++ b/src/styles/main.sass
@@ -13,5 +13,6 @@
 @import components/autosuggest
 @import components/audio-page
 @import components/upload-progress-bar
+@import components/embed
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6235,6 +6235,14 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.2.0.tgz#468edeb542b7e0538f9f9b1aeb26f034f19c86e1"
+  integrity sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -7209,6 +7217,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This pull request, is just for review and not for merging with master :) In this pull request, I'm showing the work in progress for the functionality of the embeddable audio player. I have created an embed page where the embeddable audio player lives alone. 

I have added these to the embeddable audio player:
- Basic audio buttons (ex. play & pause)
- Waveform of the audio
- "Album art" (if image URL is provided)
- Title and artist
- Current play time

I have also passed the correct audio file to the embeddable audio player and put an iframe of the embeddable audio player in the Audio page. There are hardly any styles, but will add them once I receive the designs from Stephanie. For just development, I hardcoded the audio url to point to `localhost:3000` to make sure it's receiving the correct url but will change it once I make a PR that's ready for production. 