### PR TITLE
Fix/embeddable player

### DIFF
--- a/src/scripts/app.jsx
+++ b/src/scripts/app.jsx
@@ -29,13 +29,19 @@ class Root extends React.Component {
     return (
       <div>
         <Route
-          render={history => (
-            <Header
-              auth={auth}
-              history={history}
-              onEnter={this.redirectIfLoggedOut(this)}
-            />
-          )}
+          render={history => {
+            if (history.location.pathname === "/embed") {
+              return null;
+            } else {
+              return (
+                <Header
+                  auth={auth}
+                  history={history}
+                  onEnter={this.redirectIfLoggedOut(this)}
+                />
+              );
+            }
+          }}
         />
         {auth.isAuthenticated && (
           <div>

--- a/src/scripts/app.jsx
+++ b/src/scripts/app.jsx
@@ -48,9 +48,10 @@ class Root extends React.Component {
             <Route exact path="/" component={StoreManageApp} />
             <Route path="/audio/:id" component={Audio} />
             <Route path="/activity" component={Activity} />
-            <Route path="/embed" component={Embed} />
           </div>
         )}
+
+        <Route path="/embed" component={Embed} />
       </div>
     );
   }

--- a/src/styles/components/_audio-page.sass
+++ b/src/styles/components/_audio-page.sass
@@ -282,6 +282,7 @@
   margin-bottom: 15px
 
 #embeddable-audio-player
+  height: 300px
   width: 100%
 
 =delete_button


### PR DESCRIPTION
This pull request is for review and not merging with master :)

In this pull request, I removed the header from the embed page and also made the embeddable audio player publicly accessible so users do not have to login to access it. 

I have tested the embeddable audio player in jsbin after I logged out of Resound and the embeddable audio player was accessible. Please let me know if you would like any changes, thank you for the review!