### PR TITLE
Style/embeddable player

### DIFF
--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -220,15 +220,23 @@ export default class Audio extends React.Component {
     });
   }
 
+  updateEmbedCode(audio) {
+    const embedCode = `<iframe height="210" width="100%" scrolling="no" frameborder="0" src="${this.updateIframeSrc(
+      audio
+    )}"/>`;
+
+    return embedCode;
+  }
+
   updateIframeSrc(audio) {
     const { imageUrl } = this.state;
     const { contributors, files, title } = audio;
     const audioElements = ["button", "player", "progress", "wave"];
 
     const iframeSrcObj = {
-      url: files["mp3_128"],
       contributors,
-      title
+      title,
+      url: files["mp3_128"]
     };
 
     if (imageUrl) {
@@ -243,7 +251,9 @@ export default class Audio extends React.Component {
       }
     });
 
-    const iframeSrc = `/embed?${queryString.stringify(iframeSrcObj)}`;
+    const iframeSrc = `http://localhost:8000/embed?${queryString.stringify(
+      iframeSrcObj
+    )}`;
 
     return iframeSrc;
   }
@@ -436,9 +446,7 @@ export default class Audio extends React.Component {
                     id="embed-code"
                     readOnly
                     type="text"
-                    value={`http://localhost:8000${this.updateIframeSrc(
-                      audio
-                    )}`}
+                    value={this.updateEmbedCode(audio)}
                   />
                 </div>
               )}
@@ -462,6 +470,7 @@ export default class Audio extends React.Component {
         {audio && (
           <iframe
             id="embeddable-audio-player"
+            scrolling="no"
             src={this.updateIframeSrc(audio)}
           />
         )}

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -21,14 +21,14 @@ import ColorPicker from "../color-picker/ColorPicker";
 
 const initialState = {
   addFallbackAudioElement: false,
-  buttonColor: "#2db2cc",
+  buttonColor: "rgb(41, 213, 239)",
   imageUrl: "",
   inEditMode: false,
   playerColor: "rgb(246, 246, 246)",
-  progressColor: "#0fb3cc",
+  progressColor: "rgb(41, 213, 239)",
   validTitle: true,
   validContributors: true,
-  waveColor: "#a2e0e3",
+  waveColor: "rgba(0, 0, 0, 0.1)",
   playing: false,
   pos: 0
 };
@@ -274,9 +274,9 @@ export default class Audio extends React.Component {
       normalize: true,
       barWidth: 1,
       cursorWidth: 0,
-      progressColor: "#0fb3cc",
+      progressColor: "rgb(41, 213, 239)",
       scrollParent: true,
-      waveColor: "#a2e0e3",
+      waveColor: "rgba(0, 0, 0, 0.1)",
       height: 75,
       backend: "MediaElement"
     };

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -21,14 +21,14 @@ import ColorPicker from "../color-picker/ColorPicker";
 
 const initialState = {
   addFallbackAudioElement: false,
-  buttonColor: "rgb(41, 213, 239)",
+  buttonColor: { r: 41, g: 213, b: 239, a: 1 },
   imageUrl: "",
   inEditMode: false,
-  playerColor: "rgb(246, 246, 246)",
-  progressColor: "rgb(41, 213, 239)",
+  playerColor: { r: 246, g: 246, b: 246, a: 1 },
+  progressColor: { r: 41, g: 213, b: 239, a: 1 },
   validTitle: true,
   validContributors: true,
-  waveColor: "rgba(0, 0, 0, 0.1)",
+  waveColor: { r: 0, g: 0, b: 0, a: 0.1 },
   playing: false,
   pos: 0
 };
@@ -61,10 +61,9 @@ export default class Audio extends React.Component {
 
   changeColor(element, color) {
     const { r, g, b, a } = color.rgb;
-    const rgba = `rgba(${r}, ${g}, ${b}, ${a})`;
     const state = {};
 
-    state[`${element}Color`] = rgba;
+    state[`${element}Color`] = { r, g, b, a };
 
     this.setState(state);
   }
@@ -245,9 +244,15 @@ export default class Audio extends React.Component {
 
     audioElements.forEach(audioElement => {
       const color = this.state[`${audioElement}Color`];
+      const { r, g, b, a } = color;
 
       if (color) {
-        iframeSrcObj[`${audioElement}Color`] = color;
+        if (audioElement === "wave" || audioElement === "progress") {
+          iframeSrcObj[`${audioElement}Color`] = `rgb(${r}, ${g}, ${b})`;
+          iframeSrcObj[`${audioElement}Opacity`] = a;
+        } else {
+          iframeSrcObj[`${audioElement}Color`] = `rgba(${r}, ${g}, ${b}, ${a})`;
+        }
       }
     });
 
@@ -284,9 +289,9 @@ export default class Audio extends React.Component {
       normalize: true,
       barWidth: 1,
       cursorWidth: 0,
-      progressColor: "rgb(41, 213, 239)",
+      progressColor: "#0fb3cc",
       scrollParent: true,
-      waveColor: "rgba(0, 0, 0, 0.1)",
+      waveColor: "#a2e0e3",
       height: 75,
       backend: "MediaElement"
     };
@@ -456,11 +461,12 @@ export default class Audio extends React.Component {
         <div id="color-pickers-container">
           {colorElements.map(colorElement => {
             const { color, element } = colorElement;
+            const { r, g, b, a } = color;
 
             return (
               <ColorPicker
                 changeColor={this.changeColor.bind(this, element)}
-                color={color}
+                color={`rgba(${r}, ${g}, ${b}, ${a})`}
                 element={element}
                 key={element}
               />

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -24,7 +24,7 @@ const initialState = {
   buttonColor: "#2db2cc",
   imageUrl: "",
   inEditMode: false,
-  playerColor: "white",
+  playerColor: "rgb(246, 246, 246)",
   progressColor: "#0fb3cc",
   validTitle: true,
   validContributors: true,

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -54,7 +54,7 @@ class Embed extends Component {
     this.setState({ playing: !playing });
   }
 
-  setDuration(e) {
+  initAudioPlayer(e) {
     const durationInSeconds = e.wavesurfer.backend.media.duration;
     const { progressOpacity, waveOpacity } = this.state.audio;
     const { wave } = e.wavesurfer.drawer.canvases[0];
@@ -151,7 +151,7 @@ class Embed extends Component {
                     }`}
                     onFinish={this.handleTogglePlay}
                     onPosChange={this.handlePosChange}
-                    onReady={this.setDuration}
+                    onReady={this.initAudioPlayer}
                     options={waveSurferOptions}
                     playing={this.state.playing}
                     pos={pos}

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -13,6 +13,7 @@ class Embed extends Component {
     this.state = {
       addFallbackAudioElement: false,
       audio: {},
+      currentTime: "00:00",
       playing: false
     };
 
@@ -81,7 +82,11 @@ class Embed extends Component {
                   style={{ backgroundImage: `url(${audio.image})` }}
                 />
               )}
-              <div className="embed__audio-container">
+              <div
+                className={`embed__audio-container ${
+                  audio.image ? "embed__audio-container--with-image" : ""
+                }`}
+              >
                 <div className="embed__audio-player-top">
                   <PlayPauseButton
                     color={audio.buttonColor}
@@ -89,14 +94,17 @@ class Embed extends Component {
                     playing={this.state.playing}
                   />
                   <div className="embed__audio-info">
-                    <span className="embed__title">{audio.title}</span>
-                    <span className="embed__contributors">
+                    <div className="embed__title overflow-ellipsis">
+                      {audio.title}
+                    </div>
+                    <div className="embed__contributors overflow-ellipsis">
                       {audio.contributors}
-                    </span>
+                    </div>
                   </div>
                 </div>
                 <Wavesurfer
                   audioFile={`http://localhost:3000/${audio.url}`}
+                  className="embed__waveform"
                   onPosChange={this.handlePosChange}
                   onReady={this.setDuration}
                   options={waveSurferOptions}

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -56,6 +56,12 @@ class Embed extends Component {
 
   setDuration(e) {
     const durationInSeconds = e.wavesurfer.backend.media.duration;
+    const { progressOpacity, waveOpacity } = this.state.audio;
+    const { wave } = e.wavesurfer.drawer.canvases[0];
+    const { progress } = e.wavesurfer.drawer.canvases[0];
+
+    wave.style.opacity = waveOpacity;
+    progress.style.opacity = progressOpacity;
 
     this.setState({
       audioState: "ready",
@@ -83,7 +89,7 @@ class Embed extends Component {
         ? audio.progressColor
         : "rgb(41, 213, 239)",
       responsive: true,
-      waveColor: audio.waveColor ? audio.waveColor : "rgba(0, 0, 0, 0.1)"
+      waveColor: audio.waveColor ? audio.waveColor : "rgb(0, 0, 0)"
     };
 
     return (

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import PlayPauseButton from "./PlayPauseButton";
 import { getDuration } from "../../services/audio-tools";
 import addFallbackIfNecessary from "../../services/audio-context";
 import autoBind from "react-autobind";
@@ -56,35 +57,33 @@ class Embed extends Component {
 
     return (
       <div id="embed">
-        <h3>{audio.title}</h3>
-        <p>{audio.contributors}</p>
-        {audio.image && <img id="embed__image" src={audio.image} />}
         {audio.url &&
           !this.state.addFallbackAudioElement && (
             <div
-              id="embed__audio-player"
+              className="embed__audio-player"
               style={{
                 backgroundColor: audio.playerColor ? audio.playerColor : "white"
               }}
             >
-              <div
-                id="embed__play-pause"
-                onClick={this.handleTogglePlay}
-                style={{
-                  backgroundColor: audio.buttonColor
-                    ? audio.buttonColor
-                    : "#2db2cc"
-                }}
-              >
-                {this.state.playing ? "Pause" : "Play"}
+              <div className="embed__audio-player-top">
+                <PlayPauseButton
+                  color={audio.buttonColor}
+                  handleTogglePlay={this.handleTogglePlay}
+                  playing={this.state.playing}
+                />
+                <div className="embed__audio-info">
+                  <h3>{audio.title}</h3>
+                  <p>{audio.contributors}</p>
+                </div>
               </div>
+              {audio.image && <img className="embed__image" src={audio.image} />}
               <Wavesurfer
                 audioFile={`http://localhost:3000/${audio.url}`}
                 onPosChange={this.handlePosChange}
                 options={waveSurferOptions}
                 playing={this.state.playing}
               />
-              <div id="embed__timestamp">{this.state.timestamp}</div>
+              <div className="embed__timestamp">{this.state.timestamp}</div>
             </div>
           )}
         {this.state.addFallbackAudioElement && (

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -67,29 +67,34 @@ class Embed extends Component {
                   : "rgb(246, 246, 246)"
               }}
             >
-              <div className="embed__audio-player-top">
-                <PlayPauseButton
-                  color={audio.buttonColor}
-                  handleTogglePlay={this.handleTogglePlay}
+              {audio.image && (
+                <div
+                  className="embed__image"
+                  style={{ backgroundImage: `url(${audio.image})` }}
+                />
+              )}
+              <div className="embed__audio-container">
+                <div className="embed__audio-player-top">
+                  <PlayPauseButton
+                    color={audio.buttonColor}
+                    handleTogglePlay={this.handleTogglePlay}
+                    playing={this.state.playing}
+                  />
+                  <div className="embed__audio-info">
+                    <span className="embed__title">{audio.title}</span>
+                    <span className="embed__contributors">
+                      {audio.contributors}
+                    </span>
+                  </div>
+                </div>
+                <Wavesurfer
+                  audioFile={`http://localhost:3000/${audio.url}`}
+                  onPosChange={this.handlePosChange}
+                  options={waveSurferOptions}
                   playing={this.state.playing}
                 />
-                <div className="embed__audio-info">
-                  <span className="embed__title">{audio.title}</span>
-                  <span className="embed__contributors">
-                    {audio.contributors}
-                  </span>
-                </div>
+                <div className="embed__timestamp">{this.state.timestamp}</div>
               </div>
-              {audio.image && (
-                <img className="embed__image" src={audio.image} />
-              )}
-              <Wavesurfer
-                audioFile={`http://localhost:3000/${audio.url}`}
-                onPosChange={this.handlePosChange}
-                options={waveSurferOptions}
-                playing={this.state.playing}
-              />
-              <div className="embed__timestamp">{this.state.timestamp}</div>
             </div>
           )}
         {this.state.addFallbackAudioElement && (

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -46,9 +46,9 @@ class Embed extends Component {
 
     const waveSurferOptions = {
       backend: "MediaElement",
-      barWidth: 1,
+      barWidth: 3,
       cursorWidth: 0,
-      height: 150,
+      height: 75,
       normalize: true,
       progressColor: audio.progressColor ? audio.progressColor : "#0fb3cc",
       responsive: true,
@@ -62,7 +62,9 @@ class Embed extends Component {
             <div
               className="embed__audio-player"
               style={{
-                backgroundColor: audio.playerColor ? audio.playerColor : "white"
+                backgroundColor: audio.playerColor
+                  ? audio.playerColor
+                  : "rgb(246, 246, 246)"
               }}
             >
               <div className="embed__audio-player-top">
@@ -72,11 +74,15 @@ class Embed extends Component {
                   playing={this.state.playing}
                 />
                 <div className="embed__audio-info">
-                  <h3>{audio.title}</h3>
-                  <p>{audio.contributors}</p>
+                  <span className="embed__title">{audio.title}</span>
+                  <span className="embed__contributors">
+                    {audio.contributors}
+                  </span>
                 </div>
               </div>
-              {audio.image && <img className="embed__image" src={audio.image} />}
+              {audio.image && (
+                <img className="embed__image" src={audio.image} />
+              )}
               <Wavesurfer
                 audioFile={`http://localhost:3000/${audio.url}`}
                 onPosChange={this.handlePosChange}

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -17,6 +17,7 @@ class Embed extends Component {
       audioState: "loading",
       currentTime: "00:00",
       playing: false,
+      pos: 0,
       waveState: "loading"
     };
 
@@ -43,7 +44,8 @@ class Embed extends Component {
     const currentTimeInSeconds = e.originalArgs[0];
 
     this.setState({
-      currentTime: getDuration({ duration: currentTimeInSeconds })
+      currentTime: getDuration({ duration: currentTimeInSeconds }),
+      pos: currentTimeInSeconds
     });
   }
 
@@ -62,7 +64,14 @@ class Embed extends Component {
   }
 
   render() {
-    const { audio, audioState, currentTime, duration, waveState } = this.state;
+    const {
+      audio,
+      audioState,
+      currentTime,
+      duration,
+      pos,
+      waveState
+    } = this.state;
 
     const waveSurferOptions = {
       backend: "MediaElement",
@@ -139,6 +148,7 @@ class Embed extends Component {
                     onReady={this.setDuration}
                     options={waveSurferOptions}
                     playing={this.state.playing}
+                    pos={pos}
                   />
                   {currentTime &&
                     duration && (

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -4,6 +4,7 @@ import { getDuration } from "../../services/audio-tools";
 import addFallbackIfNecessary from "../../services/audio-context";
 import autoBind from "react-autobind";
 import Wavesurfer from "react-wavesurfer";
+import wavesurfer from "wavesurfer.js";
 import qs from "qs";
 
 class Embed extends Component {
@@ -13,8 +14,10 @@ class Embed extends Component {
     this.state = {
       addFallbackAudioElement: false,
       audio: {},
+      audioState: "loading",
       currentTime: "00:00",
-      playing: false
+      playing: false,
+      waveState: "loading"
     };
 
     autoBind(this);
@@ -27,6 +30,13 @@ class Embed extends Component {
 
     // Checks if browser has AudioContext and if not add HTML5 audio element as fallback
     addFallbackIfNecessary(this);
+    this.checkWaveformState();
+  }
+
+  checkWaveformState() {
+    wavesurfer.on("waveform-ready", () => {
+      this.setState({ waveState: "ready" });
+    });
   }
 
   handlePosChange(e) {
@@ -46,12 +56,13 @@ class Embed extends Component {
     const durationInSeconds = e.wavesurfer.backend.media.duration;
 
     this.setState({
+      audioState: "ready",
       duration: getDuration({ duration: durationInSeconds })
     });
   }
 
   render() {
-    const { audio, currentTime, duration } = this.state;
+    const { audio, audioState, currentTime, duration, waveState } = this.state;
 
     const waveSurferOptions = {
       backend: "MediaElement",
@@ -59,7 +70,9 @@ class Embed extends Component {
       cursorWidth: 0,
       height: 75,
       normalize: true,
-      progressColor: audio.progressColor ? audio.progressColor : "rgb(41, 213, 239)",
+      progressColor: audio.progressColor
+        ? audio.progressColor
+        : "rgb(41, 213, 239)",
       responsive: true,
       waveColor: audio.waveColor ? audio.waveColor : "rgba(0, 0, 0, 0.1)"
     };
@@ -102,20 +115,37 @@ class Embed extends Component {
                     </div>
                   </div>
                 </div>
-                <Wavesurfer
-                  audioFile={`http://localhost:3000/${audio.url}`}
-                  className="embed__waveform"
-                  onPosChange={this.handlePosChange}
-                  onReady={this.setDuration}
-                  options={waveSurferOptions}
-                  playing={this.state.playing}
-                />
-                {currentTime &&
-                  duration && (
-                    <div className="embed__timestamp">
-                      {this.state.currentTime} / {this.state.duration}
+                <div className="embed__waveform-container">
+                  {audioState === "loading" && (
+                    <div className="embed__loading-msg pulsate">
+                      <span>loading audio...</span>
                     </div>
                   )}
+                  {audioState === "ready" &&
+                    waveState === "loading" && (
+                      <div className="embed__loading-msg pulsate">
+                        <span>loading waveform...</span>
+                      </div>
+                    )}
+                  <Wavesurfer
+                    audioFile={`http://localhost:3000/${audio.url}`}
+                    className={`embed__waveform ${
+                      audioState === "loading" || waveState === "loading"
+                        ? "hide"
+                        : ""
+                    }`}
+                    onPosChange={this.handlePosChange}
+                    onReady={this.setDuration}
+                    options={waveSurferOptions}
+                    playing={this.state.playing}
+                  />
+                  {currentTime &&
+                    duration && (
+                      <div className="embed__timestamp">
+                        {this.state.currentTime} / {this.state.duration}
+                      </div>
+                    )}
+                </div>
               </div>
             </div>
           )}

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -29,10 +29,10 @@ class Embed extends Component {
   }
 
   handlePosChange(e) {
-    const pos = e.originalArgs[0];
+    const currentTimeInSeconds = e.originalArgs[0];
 
     this.setState({
-      timestamp: getDuration({ duration: pos })
+      currentTime: getDuration({ duration: currentTimeInSeconds })
     });
   }
 
@@ -41,8 +41,16 @@ class Embed extends Component {
     this.setState({ playing: !playing });
   }
 
+  setDuration(e) {
+    const durationInSeconds = e.wavesurfer.backend.media.duration;
+
+    this.setState({
+      duration: getDuration({ duration: durationInSeconds })
+    });
+  }
+
   render() {
-    const { audio } = this.state;
+    const { audio, currentTime, duration } = this.state;
 
     const waveSurferOptions = {
       backend: "MediaElement",
@@ -90,10 +98,16 @@ class Embed extends Component {
                 <Wavesurfer
                   audioFile={`http://localhost:3000/${audio.url}`}
                   onPosChange={this.handlePosChange}
+                  onReady={this.setDuration}
                   options={waveSurferOptions}
                   playing={this.state.playing}
                 />
-                <div className="embed__timestamp">{this.state.timestamp}</div>
+                {currentTime &&
+                  duration && (
+                    <div className="embed__timestamp">
+                      {this.state.currentTime} / {this.state.duration}
+                    </div>
+                  )}
               </div>
             </div>
           )}

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -134,6 +134,7 @@ class Embed extends Component {
                         ? "hide"
                         : ""
                     }`}
+                    onFinish={this.handleTogglePlay}
                     onPosChange={this.handlePosChange}
                     onReady={this.setDuration}
                     options={waveSurferOptions}

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -59,9 +59,9 @@ class Embed extends Component {
       cursorWidth: 0,
       height: 75,
       normalize: true,
-      progressColor: audio.progressColor ? audio.progressColor : "#0fb3cc",
+      progressColor: audio.progressColor ? audio.progressColor : "rgb(41, 213, 239)",
       responsive: true,
-      waveColor: audio.waveColor ? audio.waveColor : "#a2e0e3"
+      waveColor: audio.waveColor ? audio.waveColor : "rgba(0, 0, 0, 0.1)"
     };
 
     return (

--- a/src/scripts/components/embed/PlayPauseButton.jsx
+++ b/src/scripts/components/embed/PlayPauseButton.jsx
@@ -1,0 +1,143 @@
+import React from "react";
+
+const PlayPauseButton = ({
+  color = "#29D5EF",
+  playing = false,
+  handleTogglePlay = () => {}
+}) => {
+  if (!playing) {
+    return (
+      <svg
+        class="embed__play-pause"
+        onClick={handleTogglePlay}
+        width="65px"
+        height="65px"
+        viewBox="0 0 65 65"
+        version="1.1"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlnsXlink="http://www.w3.org/1999/xlink"
+      >
+        <defs>
+          <path
+            d="M32.5,65 C14.57896,65 0,50.42104 0,32.5 C0,14.58167 14.57896,0 32.5,0 C50.42104,0 65,14.58167 65,32.5 C65,50.42104 50.42104,65 32.5,65 Z"
+            id="path-1"
+          />
+          <path
+            d="M23.93928,15.28002 L2.9117,26.04951 C1.92857,26.55302 0.72341,26.16422 0.21989,25.1811 C0.07537,24.89892 0,24.58643 0,24.26939 L0,2.73043 C0,1.62586 0.89543,0.73043 2,0.73043 C2.31703,0.73043 2.62952,0.80579 2.9117,0.95031 L23.93928,11.7198 C24.9224,12.22332 25.31121,13.42848 24.80769,14.41161 C24.61645,14.78499 24.31266,15.08879 23.93928,15.28002 Z"
+            id="path-3"
+          />
+        </defs>
+        <g
+          id="Page-1"
+          stroke="none"
+          strokeWidth="1"
+          fill="none"
+          fillRule="evenodd"
+        >
+          <g id="button-play_embed">
+            <g id="Group-3">
+              <mask id="mask-2" fill="white">
+                <use xlinkHref="#path-1" />
+              </mask>
+              <g id="Clip-2" />
+              <polygon
+                id="Fill-1"
+                fill={color}
+                mask="url(#mask-2)"
+                points="-5 -5 70 -5 70 70 -5 70"
+              />
+            </g>
+            <g id="Group-6" transform="translate(24.000000, 19.000000)">
+              <mask id="mask-4" fill="white">
+                <use xlinkHref="#path-3" />
+              </mask>
+              <g id="Clip-5" />
+              <polygon
+                id="Fill-4"
+                fill="#FFFFFF"
+                mask="url(#mask-4)"
+                points="-5 -4.26957 30.028 -4.26957 30.028 31.26982 -5 31.26982"
+              />
+            </g>
+          </g>
+        </g>
+      </svg>
+    );
+  } else {
+    return (
+      <svg
+        className="embed__play-pause"
+        onClick={handleTogglePlay}
+        width="65px"
+        height="65px"
+        viewBox="0 0 65 65"
+        version="1.1"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlnsXlink="http://www.w3.org/1999/xlink"
+      >
+        <defs>
+          <path
+            d="M32.5,65 C14.57896,65 0,50.42104 0,32.5 C0,14.58167 14.57896,0 32.5,0 C50.42104,0 65,14.58167 65,32.5 C65,50.42104 50.42104,65 32.5,65 Z"
+            id="path-1"
+          />
+          <polygon
+            id="path-3"
+            points="0.62679 26.15703 0.62679 1.52592 0.62679 0.16175 10.80536 0.17027 10.80536 1.52592 10.80536 26.15703 10.80536 27.55418 0.62679 27.62325"
+          />
+          <polygon
+            id="path-5"
+            points="0.89464 26.15703 0.89464 1.52592 0.89464 0.16175 11.07321 0.17027 11.07321 1.52592 11.07321 26.15703 11.07321 27.55418 0.89464 27.62325"
+          />
+        </defs>
+        <g
+          id="Page-1"
+          stroke="none"
+          strokeWidth="1"
+          fill="none"
+          fillRule="evenodd"
+        >
+          <g id="button">
+            <g id="Group-3">
+              <mask id="mask-2" fill="white">
+                <use xlinkHref="#path-1" />
+              </mask>
+              <g id="Clip-2" />
+              <polygon
+                id="Fill-1"
+                fill={color}
+                mask="url(#mask-2)"
+                points="-5 -5 70 -5 70 70 -5 70"
+              />
+            </g>
+            <g id="Group-6" transform="translate(19.000000, 19.000000)">
+              <mask id="mask-4" fill="white">
+                <use xlinkHref="#path-3" />
+              </mask>
+              <g id="Clip-5" />
+              <polygon
+                id="Fill-4"
+                fill="#FFFFFF"
+                mask="url(#mask-4)"
+                points="-4.37321 -4.83825 15.80536 -4.83825 15.80536 32.62325 -4.37321 32.62325"
+              />
+            </g>
+            <g id="Group-9" transform="translate(34.000000, 19.000000)">
+              <mask id="mask-6" fill="white">
+                <use xlinkHref="#path-5" />
+              </mask>
+              <g id="Clip-8" />
+              <polygon
+                id="Fill-7"
+                fill="#FFFFFF"
+                mask="url(#mask-6)"
+                points="-4.10536 -4.83825 16.07321 -4.83825 16.07321 32.62325 -4.10536 32.62325"
+              />
+            </g>
+          </g>
+        </g>
+      </svg>
+    );
+  }
+};
+
+export default PlayPauseButton;

--- a/src/scripts/components/embed/PlayPauseButton.jsx
+++ b/src/scripts/components/embed/PlayPauseButton.jsx
@@ -8,7 +8,7 @@ const PlayPauseButton = ({
   if (!playing) {
     return (
       <svg
-        class="embed__play-pause"
+        className="embed__play-pause"
         onClick={handleTogglePlay}
         width="65px"
         height="65px"

--- a/src/scripts/services/audio-tools.js
+++ b/src/scripts/services/audio-tools.js
@@ -2,8 +2,14 @@ import moment from "moment";
 
 const getCreatedAt = audio => new Date(audio.created_at).toLocaleDateString();
 
-const getDuration = audio =>
-  moment.utc(audio.duration * 1000).format("HH:mm:ss");
+const getDuration = audio => {
+  // If audio duration is an hour or longer
+  if (audio.duration >= 3600) {
+    return moment.utc(audio.duration * 1000).format("HH:mm:ss");
+  } else {
+    return moment.utc(audio.duration * 1000).format("mm:ss");
+  }
+};
 
 const generateUrl = audio => {
   const title = audio.title.replace(/\s+/g, "_");

--- a/src/styles/components/_audio-page.sass
+++ b/src/styles/components/_audio-page.sass
@@ -282,7 +282,8 @@
   margin-bottom: 15px
 
 #embeddable-audio-player
-  height: 300px
+  border: none
+  height: 250px
   width: 100%
 
 =delete_button

--- a/src/styles/components/_audio-page.sass
+++ b/src/styles/components/_audio-page.sass
@@ -283,7 +283,7 @@
 
 #embeddable-audio-player
   border: none
-  height: 250px
+  height: 210px
   width: 100%
 
 =delete_button

--- a/src/styles/components/_embed.sass
+++ b/src/styles/components/_embed.sass
@@ -1,32 +1,39 @@
 .embed__audio-player
-	height: 211px
-	padding-left: 29px
-	padding-right: 28.1px
-	padding-top: 21px
-
-.embed__audio-player-top
-	align-items: center
 	display: flex
-	margin-bottom: 25px
-
-.embed__play-pause:hover
-	cursor: pointer
+	height: 211px
+	overflow: auto
+	padding-right: 28.1px
 
 .embed__image
-	height: 100px
-	width: 100px
+	background-position: center
+	background-size: cover
+	height: 100%
+	min-width: 210px
 
-.embed__audio-info
-	display: flex
-	flex-direction: column
-	margin-left: 26px
+.embed__audio-container
+	margin-left: 29px
+	margin-top: 21px
+	width: 100%
 
-	.embed__title
-		font-size: 22px
-		font-weight: 600
+	.embed__audio-player-top
+		align-items: center
+		display: flex
+		margin-bottom: 25px
 
-	.embed__contributors
-		font-size: 20px
+	.embed__play-pause:hover
+		cursor: pointer
+
+	.embed__audio-info
+		display: flex
+		flex-direction: column
+		margin-left: 26px
+
+		.embed__title
+			font-size: 22px
+			font-weight: 600
+
+		.embed__contributors
+			font-size: 20px
 
 .embed__timestamp
 	float: right

--- a/src/styles/components/_embed.sass
+++ b/src/styles/components/_embed.sass
@@ -1,9 +1,13 @@
 .embed__audio-player
 	height: 211px
+	padding-left: 29px
+	padding-right: 28.1px
+	padding-top: 21px
 
 .embed__audio-player-top
 	align-items: center
 	display: flex
+	margin-bottom: 25px
 
 .embed__play-pause:hover
 	cursor: pointer
@@ -13,4 +17,17 @@
 	width: 100px
 
 .embed__audio-info
+	display: flex
+	flex-direction: column
 	margin-left: 26px
+
+	.embed__title
+		font-size: 22px
+		font-weight: 600
+
+	.embed__contributors
+		font-size: 20px
+
+.embed__timestamp
+	float: right
+	right: 29.1px

--- a/src/styles/components/_embed.sass
+++ b/src/styles/components/_embed.sass
@@ -95,3 +95,11 @@
 
 	.embed__audio-container--with-image
 		width: 100%
+
+	.embed__audio-container
+		.embed__audio-info
+			.embed__title
+				font-size: 16px
+
+			.embed__contributors
+				font-size: 14px

--- a/src/styles/components/_embed.sass
+++ b/src/styles/components/_embed.sass
@@ -2,7 +2,9 @@
 	display: flex
 	height: 211px
 	overflow: hidden
-	padding-right: 28.1px
+
+	wave:hover
+		cursor: pointer
 
 .embed__image
 	background-position: center
@@ -11,8 +13,10 @@
 	min-width: 210px
 
 .embed__audio-container
-	margin-left: 29px
-	margin-top: 21px
+	box-sizing: border-box
+	padding-left: 29px
+	padding-right: 28.1px
+	padding-top: 21px
 	width: 100%
 
 	.embed__audio-player-top
@@ -27,6 +31,7 @@
 		display: flex
 		flex-direction: column
 		margin-left: 26px
+		width: 80%
 
 		.embed__title
 			font-size: 22px
@@ -35,8 +40,24 @@
 		.embed__contributors
 			font-size: 20px
 
+.embed__audio-container--with-image
+  width: calc(100% - 210px)
+
 .embed__timestamp
 	float: right
 	font-size: 14px
 	margin-right: 5px
 	margin-top: 10px
+
+.overflow-ellipsis
+	overflow: hidden
+	text-overflow: ellipsis
+	white-space: nowrap
+	word-break: normal
+
+@media only screen and (max-width: 675px)
+	.embed__image
+		display: none
+
+	.embed__audio-container--with-image
+		width: 100%

--- a/src/styles/components/_embed.sass
+++ b/src/styles/components/_embed.sass
@@ -3,6 +3,9 @@
 	height: 211px
 	overflow: hidden
 
+	wave
+		overflow: hidden !important
+
 	wave:hover
 		cursor: pointer
 

--- a/src/styles/components/_embed.sass
+++ b/src/styles/components/_embed.sass
@@ -22,6 +22,20 @@
 	padding-top: 21px
 	width: 100%
 
+	.embed__waveform-container
+		position: relative
+
+	.embed__loading-msg
+		align-items: center
+		color: rgb(41, 213, 239)
+		display: flex
+		height: 100%
+		justify-content: center
+		left: 0
+		position: absolute
+		top: 0
+		width: 100%
+
 	.embed__audio-player-top
 		align-items: center
 		display: flex
@@ -61,6 +75,19 @@
 	text-overflow: ellipsis
 	white-space: nowrap
 	word-break: normal
+
+.pulsate
+	-webkit-animation: pulsate 2s ease-out
+	-webkit-animation-iteration-count: infinite
+	opacity: 0.5
+
+@-webkit-keyframes pulsate
+	0%
+		opacity: 0.4
+	50%
+		opacity: 1.0
+	100%
+		opacity: 0.5
 
 @media only screen and (max-width: 675px)
 	.embed__image

--- a/src/styles/components/_embed.sass
+++ b/src/styles/components/_embed.sass
@@ -24,6 +24,10 @@
 		display: flex
 		margin-bottom: 13px
 
+	.embed__play-pause
+		min-height: 65px
+		min-width: 65px
+
 	.embed__play-pause:hover
 		cursor: pointer
 

--- a/src/styles/components/_embed.sass
+++ b/src/styles/components/_embed.sass
@@ -1,20 +1,16 @@
-#embed__audio-player
-  border: 1px solid #e5e5e5
+.embed__audio-player
+	height: 211px
 
-#embed__play-pause:hover
-  cursor: pointer
+.embed__audio-player-top
+	align-items: center
+	display: flex
 
-#embed__image
+.embed__play-pause:hover
+	cursor: pointer
+
+.embed__image
 	height: 100px
 	width: 100px
 
-#embed__play-pause
-	align-items: center
-	border-radius: 40px
-	color: white
-	display: flex
-	float: left
-	height: 75px
-	justify-content: center
-	margin: 28px 15px 0 15px
-	width: 75px
+.embed__audio-info
+	margin-left: 26px

--- a/src/styles/components/_embed.sass
+++ b/src/styles/components/_embed.sass
@@ -1,7 +1,7 @@
 .embed__audio-player
 	display: flex
 	height: 211px
-	overflow: auto
+	overflow: hidden
 	padding-right: 28.1px
 
 .embed__image
@@ -18,7 +18,7 @@
 	.embed__audio-player-top
 		align-items: center
 		display: flex
-		margin-bottom: 25px
+		margin-bottom: 13px
 
 	.embed__play-pause:hover
 		cursor: pointer
@@ -37,4 +37,6 @@
 
 .embed__timestamp
 	float: right
-	right: 29.1px
+	font-size: 14px
+	margin-right: 5px
+	margin-top: 10px


### PR DESCRIPTION
This pull request is just for review and not for merging :) In this pull request, I have styled the Resound embeddable audio player and also fixed some bugs.

Here are the bugs that I have fixed:
- When `rgba` code is fed to the `Wavesurfer`, the wave color changes when resizing the embeddable audio player.
- Fixed embed code so embeddable audio player will have fixed height and width so size will stay the same wherever it's embedded

When the `Wavesurfer` is given an `rgba` code for the wave and progress color, `react-wavesurfer` changes the color of the wave when its waveforms are being resized. So I had to manually change the opacity by grabbing the `wavesurfer` object and grabbing the wave and progress element to update the opacity style.

I have also added a loading message for large audio files, so users will know that the audio or waveform is loading and that the player is not broken.

I have also created a `PlayPauseButton` component because I had to dynamically change the color of the play and pause svgs. In order to do that, I had to render the SVG document since an SVG in an image tag cannot be manipulated by CSS.
Here is a link for more information on dynamically changing the color of SVGs with React:
https://blog.lftechnology.com/using-svg-icons-components-in-react-44fbe8e5f91

I have also updated the `getDuration` audio tool, so any audio that is over an hour will be in the format of `HH:mm:ss` while audio less than hour will be `mm:ss`.

Please let me know if you have any questions, thank you for the review!