### PR TITLE
Feat/embeddable player

### DIFF
--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -346,9 +346,7 @@ export default class Audio extends React.Component {
                   )}
                 {addFallbackAudioElement && (
                   <audio controls>
-                    <source
-                      src={audio.files["mp3_128"]}
-                    />
+                    <source src={audio.files["mp3_128"]} />
                   </audio>
                 )}
                 <div className="row waveform__timestamp">

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -13,7 +13,6 @@ import CopyDownload from "./CopyDownload";
 import EmbedConfig from "../embed/EmbedConfig";
 import autoBind from "react-autobind";
 import { getDuration, isValidLength } from "../../services/audio-tools";
-import addFallbackIfNecessary from "../../services/audio-context";
 import ContributorStore from "../../components/contributor/contributor-store";
 import SingleAudioDropzone from "./SingleAudioDropzone";
 import DropstripStore from "../dropstrip/dropstrip-store";
@@ -44,9 +43,6 @@ export default class Audio extends React.Component {
     AudioStore.fetch(this.audioId);
     ContributorStore.addChangeListener(this.populateContributorsSuggestions);
     ContributorStore.get();
-
-    // Checks if browser has AudioContext and if not add HTML5 audio element as fallback
-    addFallbackIfNecessary(this);
   }
 
   componentWillUnmount() {
@@ -299,8 +295,7 @@ export default class Audio extends React.Component {
                   </div>
                 )}
                 {!this.state.replacing &&
-                  audio.files &&
-                  !addFallbackAudioElement && (
+                  audio.files && (
                     <div className="row playwave__container">
                       <AudioPlayPause
                         editing={editing}
@@ -344,11 +339,6 @@ export default class Audio extends React.Component {
                       </div>
                     </div>
                   )}
-                {addFallbackAudioElement && (
-                  <audio controls>
-                    <source src={audio.files["mp3_128"]} />
-                  </audio>
-                )}
                 <div className="row waveform__timestamp">
                   {this.state.timestamp}
                 </div>

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -318,9 +318,7 @@ export default class Audio extends React.Component {
                           )}
                           {this.state.waveState && (
                             <Wavesurfer
-                              audioFile={`http://localhost:3000${
-                                audio.files["mp3_128"]
-                              }`}
+                              audioFile={audio.files["mp3_128"]}
                               pos={this.state.pos}
                               onPosChange={this.handlePosChange}
                               onFinish={this.handleTogglePlay}
@@ -349,7 +347,7 @@ export default class Audio extends React.Component {
                 {addFallbackAudioElement && (
                   <audio controls>
                     <source
-                      src={`http://localhost:3000${audio.files["mp3_128"]}`}
+                      src={audio.files["mp3_128"]}
                     />
                   </audio>
                 )}

--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -377,7 +377,6 @@ export default class Audio extends React.Component {
                 <div className="col s10 offset-s2">
                   {showEmbedConfig ? (
                     <EmbedConfig
-                      addFallbackAudioElement={addFallbackAudioElement}
                       audio={audio}
                       toggleEmbedConfig={this.toggleEmbedConfig}
                     />

--- a/src/scripts/components/color-picker/ColorPicker.jsx
+++ b/src/scripts/components/color-picker/ColorPicker.jsx
@@ -1,15 +1,21 @@
 import React from "react";
-import { ChromePicker } from "react-color";
+import { Hue, Saturation } from "react-color/lib/components/common";
+import { CustomPicker } from "react-color";
 
-const ColorPicker = props => {
-  const { changeColor, color, element } = props;
-
-  return (
-    <div>
-      <p>{element} color</p>
-      <ChromePicker color={color} onChange={changeColor} />
+const ColorPicker = props => (
+  <div className="color-picker">
+    <div className="color-picker__saturation">
+      <Saturation {...props} />
     </div>
-  );
-};
+    <div className="color-picker__hue">
+      <Hue
+        {...props}
+        pointer={() => {
+          return <div className="color-picker__pointer" />;
+        }}
+      />
+    </div>
+  </div>
+);
 
-export default ColorPicker;
+export default CustomPicker(ColorPicker);

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -13,7 +13,6 @@ class Embed extends Component {
     super(props);
 
     this.state = {
-      addFallbackAudioElement: false,
       audio: {},
       audioState: "loading",
       currentTime: "00:00",
@@ -57,12 +56,6 @@ class Embed extends Component {
 
   initAudioPlayer(e) {
     const durationInSeconds = e.wavesurfer.backend.media.duration;
-    const { progressOpacity, waveOpacity } = this.state.audio;
-    const { wave } = e.wavesurfer.drawer.canvases[0];
-    const { progress } = e.wavesurfer.drawer.canvases[0];
-
-    wave.style.opacity = waveOpacity;
-    progress.style.opacity = progressOpacity;
 
     this.setState({
       audioState: "ready",
@@ -94,11 +87,9 @@ class Embed extends Component {
       cursorWidth: 0,
       height: 75,
       normalize: true,
-      progressColor: audio.progressColor
-        ? audio.progressColor
-        : "rgb(41, 213, 239)",
+      progressColor: audio.accentColor ? audio.accentColor : "#29D5EF",
       responsive: true,
-      waveColor: audio.waveColor ? audio.waveColor : "rgb(0, 0, 0)"
+      waveColor: audio.waveColor ? audio.waveColor : "#CDCDCD"
     };
 
     return (
@@ -107,9 +98,7 @@ class Embed extends Component {
           <div
             className="embed__audio-player"
             style={{
-              backgroundColor: audio.playerColor
-                ? audio.playerColor
-                : "rgb(246, 246, 246)"
+              backgroundColor: audio.playerColor ? audio.playerColor : "#F6F6F6"
             }}
           >
             {audio.image && (
@@ -125,7 +114,7 @@ class Embed extends Component {
             >
               <div className="embed__audio-player-top">
                 <PlayPauseButton
-                  color={audio.buttonColor}
+                  color={audio.accentColor}
                   handleTogglePlay={this.handleTogglePlay}
                   playing={this.state.playing}
                 />
@@ -143,9 +132,7 @@ class Embed extends Component {
                   <div
                     className="embed__loading-msg pulsate"
                     style={{
-                      color: audio.buttonColor
-                        ? audio.buttonColor
-                        : "rgb(41, 213, 239)"
+                      color: audio.accentColor ? audio.accentColor : "#29D5EF"
                     }}
                   >
                     <span>loading audio...</span>
@@ -157,9 +144,7 @@ class Embed extends Component {
                     <div
                       className="embed__loading-msg pulsate"
                       style={{
-                        color: audio.buttonColor
-                          ? audio.buttonColor
-                          : "rgb(41, 213, 239)"
+                        color: audio.accentColor ? audio.accentColor : "#29D5EF"
                       }}
                     >
                       <span>loading waveform...</span>

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -119,10 +119,16 @@ class Embed extends Component {
                   playing={this.state.playing}
                 />
                 <div className="embed__audio-info">
-                  <div className="embed__title overflow-ellipsis">
+                  <div
+                    className="embed__title overflow-ellipsis"
+                    style={{ color: audio.textColor }}
+                  >
                     {audio.title}
                   </div>
-                  <div className="embed__contributors overflow-ellipsis">
+                  <div
+                    className="embed__contributors overflow-ellipsis"
+                    style={{ color: audio.textColor }}
+                  >
                     {audio.contributors}
                   </div>
                 </div>
@@ -173,7 +179,10 @@ class Embed extends Component {
                 )}
                 {currentTime &&
                   duration && (
-                    <div className="embed__timestamp">
+                    <div
+                      className="embed__timestamp"
+                      style={{ color: audio.textColor }}
+                    >
                       {this.state.currentTime} / {this.state.duration}
                     </div>
                   )}

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -167,7 +167,7 @@ class Embed extends Component {
                   />
                 ) : (
                   <Wavesurfer
-                    audioFile={`http://localhost:3000/${audio.url}`}
+                    audioFile={audio.url}
                     className={"embed__waveform"}
                     onFinish={this.handleTogglePlay}
                     onPosChange={this.handlePosChange}

--- a/src/scripts/components/embed/EmbedConfig.jsx
+++ b/src/scripts/components/embed/EmbedConfig.jsx
@@ -19,6 +19,7 @@ class EmbedConfig extends Component {
       showAccentColorPicker: false,
       showPlayerColorPicker: false,
       showWaveColorPicker: false,
+      textColor: "black",
       waveColor: "#CDCDCD"
     };
 
@@ -26,8 +27,23 @@ class EmbedConfig extends Component {
   }
 
   changeColor(element, color) {
-    const { hex } = color;
+    const { hex, rgb } = color;
+    const { r, g, b } = rgb;
     const state = {};
+
+    if (element === "player") {
+      const o = Math.round(
+        (parseInt(r) * 299 + parseInt(g) * 587 + parseInt(b) * 114) / 1000
+      );
+
+      // If the background color is bright change the text color to black
+      if (o > 125) {
+        state.textColor = "black";
+      } else {
+        // If background color is dark change the text color to white
+        state.textColor = "white";
+      }
+    }
 
     state[`${element}Color`] = hex;
 
@@ -53,7 +69,7 @@ class EmbedConfig extends Component {
   updateIframeSrc(audio) {
     const { imageUrl } = this.state;
     const { contributors, files, title } = audio;
-    const audioElements = ["accent", "player", "wave"];
+    const audioElements = ["accent", "player", , "text", "wave"];
 
     const iframeSrcObj = {
       contributors,

--- a/src/scripts/components/embed/EmbedConfig.jsx
+++ b/src/scripts/components/embed/EmbedConfig.jsx
@@ -32,22 +32,42 @@ class EmbedConfig extends Component {
     const state = {};
 
     if (element === "player") {
-      const o = Math.round(
-        (parseInt(r) * 299 + parseInt(g) * 587 + parseInt(b) * 114) / 1000
-      );
+      if (r !== undefined && g !== undefined && b !== undefined) {
+        const o = Math.round(
+          (parseInt(r) * 299 + parseInt(g) * 587 + parseInt(b) * 114) / 1000
+        );
 
-      // If the background color is bright change the text color to black
-      if (o > 125) {
-        state.textColor = "black";
-      } else {
-        // If background color is dark change the text color to white
-        state.textColor = "white";
+        // If the background color is bright change the text color to black
+        if (o > 125) {
+          state.textColor = "black";
+        } else {
+          // If background color is dark change the text color to white
+          state.textColor = "white";
+        }
       }
     }
 
     state[`${element}Color`] = hex;
 
     this.setState(state);
+  }
+
+  hexToRgb(hex) {
+    // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
+    var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+    hex = hex.replace(shorthandRegex, function(m, r, g, b) {
+      return r + r + g + g + b + b;
+    });
+
+    var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+
+    return result
+      ? {
+          r: parseInt(result[1], 16),
+          g: parseInt(result[2], 16),
+          b: parseInt(result[3], 16)
+        }
+      : null;
   }
 
   toggleColorPicker(element) {
@@ -104,7 +124,8 @@ class EmbedConfig extends Component {
     const validHexCode = regExp.test(hex);
 
     if (validHexCode) {
-      this.changeColor(element, { hex });
+      const rgb = this.hexToRgb(hex);
+      this.changeColor(element, { hex, rgb });
     }
   }
 

--- a/src/scripts/components/embed/EmbedConfig.jsx
+++ b/src/scripts/components/embed/EmbedConfig.jsx
@@ -86,7 +86,7 @@ class EmbedConfig extends Component {
       iframeSrcObj[`${audioElement}Color`] = color;
     });
 
-    const iframeSrc = `http://localhost:8000/embed?${queryString.stringify(
+    const iframeSrc = `${window.location.origin}/embed?${queryString.stringify(
       iframeSrcObj
     )}`;
 

--- a/src/scripts/components/embed/EmbedConfig.jsx
+++ b/src/scripts/components/embed/EmbedConfig.jsx
@@ -3,6 +3,7 @@ import autoBind from "react-autobind";
 import CopyToClipboard from "react-copy-to-clipboard";
 import queryString from "query-string";
 import { EditableInput } from "react-color/lib/components/common";
+import ColorPicker from "../color-picker/ColorPicker";
 import IconClose from "./icons/IconClose";
 import IconColorPicker from "./icons/IconColorPicker";
 import IconCopy from "./icons/IconCopy";
@@ -15,6 +16,9 @@ class EmbedConfig extends Component {
       accentColor: "#29D5EF",
       embedCopied: false,
       playerColor: "#F6F6F6",
+      showAccentColorPicker: false,
+      showPlayerColorPicker: false,
+      showWaveColorPicker: false,
       waveColor: "#CDCDCD"
     };
 
@@ -27,6 +31,14 @@ class EmbedConfig extends Component {
 
     state[`${element}Color`] = hex;
 
+    this.setState(state);
+  }
+
+  toggleColorPicker(element) {
+    const showColorPicker = !this.state[`show${element}ColorPicker`];
+    const state = {};
+
+    state[`show${element}ColorPicker`] = showColorPicker;
     this.setState(state);
   }
 
@@ -82,12 +94,35 @@ class EmbedConfig extends Component {
 
   render() {
     const { audio, toggleEmbedConfig } = this.props;
-    const { accentColor, embedCopied, playerColor, waveColor } = this.state;
+    const {
+      accentColor,
+      embedCopied,
+      playerColor,
+      showAccentColorPicker,
+      showPlayerColorPicker,
+      showWaveColorPicker,
+      waveColor
+    } = this.state;
 
     const colorElements = [
-      { color: playerColor, element: "player", title: "Background Color" },
-      { color: accentColor, element: "accent", title: "Accent Color" },
-      { color: waveColor, element: "wave", title: "Wave Color" }
+      {
+        color: playerColor,
+        element: "player",
+        showColorPicker: showPlayerColorPicker,
+        title: "Background Color"
+      },
+      {
+        color: accentColor,
+        element: "accent",
+        showColorPicker: showAccentColorPicker,
+        title: "Accent Color"
+      },
+      {
+        color: waveColor,
+        element: "wave",
+        showColorPicker: showWaveColorPicker,
+        title: "Wave Color"
+      }
     ];
 
     return (
@@ -115,23 +150,20 @@ class EmbedConfig extends Component {
           </span>
           <div className="expanded-embed__color-pickers">
             {colorElements.map(colorElement => {
+              const { color, element, showColorPicker, title } = colorElement;
+
               return (
-                <div key={colorElement.title}>
-                  <span className="expanded-embed__color-type">
-                    {colorElement.title}
-                  </span>
+                <div key={title}>
+                  <span className="expanded-embed__color-type">{title}</span>
                   <div className="expanded-embed__color-picker-container">
                     <div
                       className="expanded-embed__color-box"
                       style={{
-                        backgroundColor: colorElement.color
+                        backgroundColor: color
                       }}
                     />
                     <EditableInput
-                      onChange={this.validateColor.bind(
-                        this,
-                        colorElement.element
-                      )}
+                      onChange={this.validateColor.bind(this, element)}
                       style={{
                         input: {
                           boxSizing: "border-box",
@@ -140,9 +172,20 @@ class EmbedConfig extends Component {
                           width: "80px"
                         }
                       }}
-                      value={colorElement.color}
+                      value={color}
                     />
-                    <IconColorPicker />
+                    <IconColorPicker
+                      toggleColorPicker={this.toggleColorPicker.bind(
+                        this,
+                        element.charAt(0).toUpperCase() + element.slice(1)
+                      )}
+                    />
+                    {showColorPicker && (
+                      <ColorPicker
+                        color={color}
+                        onChange={this.changeColor.bind(this, element)}
+                      />
+                    )}
                   </div>
                 </div>
               );

--- a/src/scripts/components/embed/IEEmbedPlayer.jsx
+++ b/src/scripts/components/embed/IEEmbedPlayer.jsx
@@ -83,7 +83,7 @@ class IEEmbedPlayer extends Component {
           onTimeUpdate={this.updateProgress}
           ref={audio => (this.audio = audio)}
         >
-          <source src={`http://localhost:3000/${audio.url}`} />
+          <source src={audio.url} />
         </audio>
       </div>
     );

--- a/src/scripts/components/embed/IEEmbedPlayer.jsx
+++ b/src/scripts/components/embed/IEEmbedPlayer.jsx
@@ -71,9 +71,7 @@ class IEEmbedPlayer extends Component {
             backgroundColor: audio.waveColor
               ? audio.waveColor
               : "rgba(0, 0, 0, 0.1)",
-            color: audio.progressColor
-              ? audio.progressColor
-              : "rgb(41, 213, 239)"
+            color: audio.accentColor ? audio.accentColor : "rgb(41, 213, 239)"
           }}
           value={progressValue}
         />

--- a/src/scripts/components/embed/icons/IconColorPicker.jsx
+++ b/src/scripts/components/embed/icons/IconColorPicker.jsx
@@ -1,11 +1,12 @@
 import React from "react";
 
-const IconColorPicker = () => {
+const IconColorPicker = ({ toggleColorPicker }) => {
   return (
     <svg
       className="expanded-embed__color-picker-icon"
       width="34px"
       height="34px"
+      onClick={toggleColorPicker}
       viewBox="0 0 34 34"
       version="1.1"
       xmlns="http://www.w3.org/2000/svg"

--- a/src/styles/components/_embed-config.sass
+++ b/src/styles/components/_embed-config.sass
@@ -119,10 +119,5 @@
           height: 35px
           width: 35px
 
-        .expanded-embed__color-code
-          box-sizing: border-box
-          height: 35px
-          width: 80px
-
         .expanded-embed__color-picker-icon
           margin-left: 10.4px

--- a/src/styles/components/_embed-config.sass
+++ b/src/styles/components/_embed-config.sass
@@ -65,7 +65,6 @@
     margin-top: 52.5px
 
     input
-      color: rgb(153, 153, 153)
       height: 55px
 
   .expanded-embed__embed-code
@@ -114,6 +113,7 @@
       .expanded-embed__color-picker-container
         display: flex
         margin-top: 5px
+        position: relative
 
         .expanded-embed__color-box
           height: 35px
@@ -121,3 +121,55 @@
 
         .expanded-embed__color-picker-icon
           margin-left: 10.4px
+
+        .expanded-embed__color-picker-icon:hover
+          cursor: pointer
+
+    .color-picker
+      background-color: white
+      bottom: 0
+      box-shadow: 0px 2px 6px 0px rgba(0, 0, 0, 0.5)
+      -moz-box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.5)
+      -webkit-box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.5)
+      position: absolute
+      right: -125px
+      width: 110px
+      z-index: 2
+
+    .color-picker:before
+      background-color: white
+      box-shadow: -3px 4px 4px -3px rgba(0, 0, 0, 0.5)
+      content: ""
+      left: -6px
+      height: 12px
+      position: absolute
+      top: 80%
+      transform: rotate(45deg)
+      -moz-transform: rotate(45deg)
+      -ms-transform: rotate(45deg)
+      -o-transform: rotate(45deg)
+      -webkit-transform: rotate(45deg)
+      width: 15px
+
+    .color-picker__saturation
+      height: 72.5px
+      position: relative
+
+    .color-picker__hue
+      height: 10px
+      margin-bottom: 16px
+      margin-left: 10px
+      margin-top: 16px
+      position: relative
+      width: 91px
+
+    .color-picker__pointer
+      background-color: white
+      border-radius: 100px
+      box-shadow: 0px 0px 1px 0px rgba(0, 0, 0, 0.5)
+      -webkit-box-shadow: 0px 0px 1px 0px rgba(0, 0, 0, 0.5)
+      -moz-box-shadow: 0px 0px 1px 0px rgba(0, 0, 0, 0.5)
+      height: 11px
+      margin-left: -5px
+      margin-top: -1px
+      width: 11px

--- a/src/styles/components/_embed.sass
+++ b/src/styles/components/_embed.sass
@@ -1,5 +1,6 @@
 .embed__audio-player
 	display: flex
+	display: -webkit-flex
 	height: 211px
 	overflow: hidden
 
@@ -28,17 +29,22 @@
 	.embed__loading-msg
 		align-items: center
 		display: flex
+		display: -webkit-flex
 		height: 100%
 		justify-content: center
 		left: 0
 		position: absolute
 		top: 0
 		width: 100%
+		-webkit-align-items: center
+		-webkit-justify-content: center
 
 	.embed__audio-player-top
 		align-items: center
 		display: flex
+		display: -webkit-flex
 		margin-bottom: 13px
+		-webkit-align-items: center
 
 	.embed__play-pause
 		min-height: 65px
@@ -49,9 +55,11 @@
 
 	.embed__audio-info
 		display: flex
+		display: -webkit-flex
 		flex-direction: column
 		margin-left: 26px
 		width: 80%
+		-webkit-flex-direction: column
 
 		.embed__title
 			font-size: 22px

--- a/src/styles/components/_embed.sass
+++ b/src/styles/components/_embed.sass
@@ -128,6 +128,8 @@
 
 	.embed__audio-container
 		.embed__audio-info
+			width: 70%
+
 			.embed__title
 				font-size: 16px
 


### PR DESCRIPTION
In this pull request, I have styled the color pickers and removed rgb as an option. Also, inserting hex code in the color inputs will also update the color of the embeddable player. In addition, the text color will change depending on the background color for visibility. 

I have removed localhost as the domain and tested the embeddable player in staging on Chrome, Safari, Firefox, Internet Explorer, and Edge.

I have created the documentation for the embeddable player in gitbook here:
https://legacy.gitbook.com/book/resound/resound-store-manage/edit#/edit/changes/1/how-do-i-embed-an-audio-player.md?_k=xipnsf