### PR TITLE
Secure/embeddable player

### DIFF
--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -18,7 +18,6 @@ import SingleAudioDropzone from "./SingleAudioDropzone";
 import DropstripStore from "../dropstrip/dropstrip-store";
 
 const initialState = {
-  addFallbackAudioElement: false,
   imageUrl: "",
   inEditMode: false,
   showEmbedConfig: false,
@@ -207,7 +206,7 @@ export default class Audio extends React.Component {
   }
 
   render() {
-    const { addFallbackAudioElement, audio, showEmbedConfig } = this.state;
+    const { audio, showEmbedConfig } = this.state;
 
     const editing = this.state.inEditMode;
     const validForm = this.state.validTitle && this.state.validContributors;

--- a/src/scripts/components/embed/EmbedConfig.jsx
+++ b/src/scripts/components/embed/EmbedConfig.jsx
@@ -88,14 +88,9 @@ class EmbedConfig extends Component {
 
   updateIframeSrc(audio) {
     const { imageUrl } = this.state;
-    const { contributors, files, title } = audio;
-    const audioElements = ["accent", "player", , "text", "wave"];
+    const audioElements = ["accent", "player", "text", "wave"];
 
-    const iframeSrcObj = {
-      contributors,
-      title,
-      url: files["mp3_128"]
-    };
+    const iframeSrcObj = { id: audio.id };
 
     if (imageUrl) {
       iframeSrcObj.image = imageUrl;


### PR DESCRIPTION
In this pull request, I removed the audio file, contributors, and title from the query params so it won't be editable through them.

Instead, I added the audio id to the query params to retrieve the audio file, contributors, and title from the audio object.

I have also removed `addFallbackAudioElement` from the state because it's no longer used.

In order to retrieve the data from the audio object I had to change the back-end because before the user needed to be authorized to retrieve the audio data.

Here is the link to the PR for `resound-api` where I added a script so anyone can view the embed without needing to be authorized:
https://github.com/ProjectResound/resound-api/pull/29