### PR TITLE
Cache/waveform

### DIFF
--- a/src/scripts/components/audio/Audio.jsx
+++ b/src/scripts/components/audio/Audio.jsx
@@ -115,10 +115,16 @@ export default class Audio extends React.Component {
       completed: true,
       replacing: false
     });
+
     if (this.waveNode) {
       const mp3Url = this.state.audio.files["mp3_128"];
       this.waveNode._loadAudio(mp3Url);
     }
+
+    AudioActions.save({
+      id: this.audioId,
+      peaks: ""
+    });
   }
 
   onUploadError() {
@@ -206,7 +212,7 @@ export default class Audio extends React.Component {
   }
 
   render() {
-    const { audio, showEmbedConfig } = this.state;
+    const { audio, replacing, showEmbedConfig } = this.state;
 
     const editing = this.state.inEditMode;
     const validForm = this.state.validTitle && this.state.validContributors;
@@ -363,6 +369,7 @@ export default class Audio extends React.Component {
                   {showEmbedConfig ? (
                     <EmbedConfig
                       audio={audio}
+                      replacing={replacing}
                       toggleEmbedConfig={this.toggleEmbedConfig}
                     />
                   ) : (

--- a/src/scripts/components/embed/Embed.jsx
+++ b/src/scripts/components/embed/Embed.jsx
@@ -63,7 +63,7 @@ class Embed extends Component {
 
     if (!audio.peaks || audio.peaks.length === 0) {
       wavesurfer.on("waveform-ready", () => {
-        const peaks = wavesurfer.backend.mergedPeaks;
+        const peaks = wavesurfer.backend.getPeaks(300, 0, 300);
 
         if (peaks) {
           AudioActions.save({

--- a/src/scripts/components/embed/EmbedConfig.jsx
+++ b/src/scripts/components/embed/EmbedConfig.jsx
@@ -125,7 +125,7 @@ class EmbedConfig extends Component {
   }
 
   render() {
-    const { audio, toggleEmbedConfig } = this.props;
+    const { audio, replacing, toggleEmbedConfig } = this.props;
     const {
       accentColor,
       embedCopied,
@@ -171,11 +171,14 @@ class EmbedConfig extends Component {
             Configure the player using the options below.
           </span>
         </div>
-        <iframe
-          id="embeddable-audio-player"
-          scrolling="no"
-          src={this.updateIframeSrc(audio)}
-        />
+        {!replacing &&
+          audio.files && (
+            <iframe
+              id="embeddable-audio-player"
+              scrolling="no"
+              src={this.updateIframeSrc(audio)}
+            />
+          )}
         <div className="expanded-embed__color">
           <span className="expanded-embed__color-title expanded-embed__config-titles">
             Color

--- a/src/scripts/services/resound-api.js
+++ b/src/scripts/services/resound-api.js
@@ -63,7 +63,8 @@ export default {
       body: JSON.stringify({
         title: audio.title,
         contributors: audio.contributors,
-        tags: audio.tags
+        tags: audio.tags,
+        peaks: audio.peaks
       })
     }).then(response => response.json());
   },


### PR DESCRIPTION
In this pull request, I cached the waveform after its first load so there would no longer be a wait for the waveform to be drawn. I have also replaced the cached waveform when the audio is replaced.

Here's the PR where I cached the waveform to the audio object:
https://github.com/ProjectResound/resound-api/pull/30