### PR TITLE
Fix bug where iframe is duplicated in Outpost

### DIFF
--- a/src/scripts/components/embed/EmbedConfig.jsx
+++ b/src/scripts/components/embed/EmbedConfig.jsx
@@ -81,7 +81,7 @@ class EmbedConfig extends Component {
   updateEmbedCode(audio) {
     const embedCode = `<iframe height="210" width="100%" scrolling="no" frameborder="0" src="${this.updateIframeSrc(
       audio
-    )}"/>`;
+    )}"></iframe>`;
 
     return embedCode;
   }


### PR DESCRIPTION
In this pull request, I fixed a bug where pasting the embed in Outpost creates a duplicate. It's because an iframe should not be a self-closing tag since Outpost gets confused where the iframe ends. With the self-closing iframe in Outpost, the first iframe is autocorrected to have a closing tag while the second one engulfs the content of the next element creating two embeds.

Therefore, I just made sure that the iframe looks like `<iframe></iframe>` and not `<iframe />`. I have tested this in staging and in Outpost and the embed is no longer duplicated.